### PR TITLE
Faster travis builds?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 before_install:
   - git submodule update --init --recursive
 language: node_js


### PR DESCRIPTION
[Apparently][1], explicitly disabling `sudo` on the Travis build should speed things up.

[1]: http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade