### PR TITLE
Remove `git submodule update` call from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-before_install:
-  - git submodule update --init --recursive
 language: node_js
 node_js:
   - "0.10"


### PR DESCRIPTION
I don't think this is necessary any more, as all the submodules seem to be gone.