### PR TITLE
Don't include `config.json` in the SASS watch-list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function( grunt ) {
         },
         watch: {
             sass: {
-                files: [ 'config.json', 'grid/sass/**/*.scss', 'src/sass/**/*.scss', 'src/widget/**/*.scss' ],
+                files: [ 'grid/sass/**/*.scss', 'src/sass/**/*.scss', 'src/widget/**/*.scss' ],
                 tasks: [ 'style' ],
                 options: {
                     spawn: true,


### PR DESCRIPTION
Pretty sure it's no longer necessary to recompile SASS if `config.json` changes.