### PR TITLE
Make `FormModel.types` accessible publicly

### DIFF
--- a/src/js/FormModel.js
+++ b/src/js/FormModel.js
@@ -1188,5 +1188,7 @@ define( function( require, exports, module ) {
         }
     };
 
+    FormModel.types = types;
+
     module.exports = FormModel;
 } );


### PR DESCRIPTION
This allows widgets or other extensions to add validation for custom data types.

Issue: #311