### PR TITLE
Use `prop(..., false)` instead of `removeAttr(...)` in filepicker

### DIFF
--- a/src/widget/file/filepicker.js
+++ b/src/widget/file/filepicker.js
@@ -82,7 +82,7 @@ define( function( require, exports, module ) {
             .then( function() {
                 that._showFeedback();
                 that._changeListener();
-                $input.removeAttr( 'disabled' );
+                $input.prop( 'disabled', false );
                 if ( existingFileName ) {
                     fileManager.getFileUrl( existingFileName )
                         .then( function( url ) {


### PR DESCRIPTION
* `disabled` should be controlled via jQuery's `prop()` method rather than
   attr methods
* `removeProp()` is not suitable, because it prevents the field ever becoming
  disabled again:

  > Do not use this method to remove native properties such as checked, disabled, or selected. This will remove the property completely and, once removed, cannot be added again to element.
  > — _https://api.jquery.com/removeProp/_