### PR TITLE
Scroll to the top of the form when flipping pages

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -65,9 +65,7 @@ define( function( require, exports, module ) {
 
             loadErrors = loadErrors.concat( form.init() );
 
-            if ( window.scrollTo ) {
-                window.scrollTo( 0, 0 );
-            }
+            $( formSelector )[ 0 ].scrollIntoView();
 
             return loadErrors;
         };
@@ -428,9 +426,7 @@ define( function( require, exports, module ) {
                     this.toggleButtons( newIndex );
                 }
 
-                if ( window.scrollTo ) {
-                    window.scrollTo( 0, 0 );
-                }
+                pageEl.scrollIntoView();
 
                 $( pageEl ).trigger( 'pageflip.enketo' );
             },
@@ -1860,12 +1856,13 @@ define( function( require, exports, module ) {
                 .then( function() {
                     $firstError = $form.find( '.invalid-required, .invalid-constraint' ).eq( 0 );
 
-                    if ( $firstError.length > 0 && window.scrollTo ) {
+                    if ( $firstError.length > 0 ) {
                         if ( that.pages.active ) {
                             // move to the first page with an error
                             that.pages.flipToPageContaining( $firstError );
                         }
-                        window.scrollTo( 0, $firstError.offset().top - 50 );
+
+                        $firstError[ 0 ].scrollIntoView();
                     }
                     return $firstError.length === 0;
                 } )


### PR DESCRIPTION
If the scrolling region for the form is not actually `window`, then the old code
would not scroll to the top of it.

This commit replaces use of `window.scrollTo()` with
`$( formSelector ).scrollIntoView()`.

Issue: #331