### PR TITLE
Return a promise wrapping new page index when turning to next page

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -390,17 +390,21 @@ define( function( require, exports, module ) {
                 this.updateAllActive();
                 currentIndex = this.getCurrentIndex();
 
-                form.validateContent( this.$current )
+                return form.validateContent( this.$current )
                     .then( function( valid ) {
-                        var next;
+                        var next, newIndex;
 
-                        if ( !valid ) return;
+                        if ( !valid ) return false;
 
                         next = that.getNext( currentIndex );
 
                         if ( next ) {
-                            that.flipTo( next, currentIndex + 1 );
+                            newIndex = currentIndex + 1;
+                            that.flipTo( next, newIndex );
+                            return newIndex;
                         }
+
+                        return true;
                     } );
             },
             prev: function() {


### PR DESCRIPTION
## Functionality

This changes the `pages.next()` function to return a `Promise`, wrapping one of the following values:

value | meaning
-----|-----
`false` | validation failed
`true` | validation passed, but the page did not change
`number` | the index into `$activePages` of the new page

## Use case

In our app, we want to add an item to the browser history representing each page of the form.  With this change, code such as this can be written:

```javascript
form.getView().pages.next()
    .then( function( newPageIndex ) {
        window.history.pushState( { enketo_page_number: newPageIndex - 1 }, '' );
    } );

...

$( window ).on( 'popstate', function( event ) {
    var pages, targetPage;
    if ( event.originalEvent.state && event.originalEvent.state.enketo_page_number ) {
        targetPage = event.originalEvent.state.enketo_page;
        pages = form.getView().pages;
        pages.flipTo( pages.getAllActive()[ targetPage ], targetPage);
    }
} );
```

### Notes
* we are overwriting both the `prev` and `next` buttons to work with browser history as follows:
```javascript
$( '#my-form .btn.next-page' )
    .off( '.pagemode' )
    .on( 'click.pagemode', function() {
        form.getView().pages.next()
            .then( function( newPageIndex ) {
                if( typeof newPageIndex === 'number' ) {
                    window.history.pushState( { enketo_page_number: newPageIndex - 1 }, '' );
                }
            } );
            return false;
        } );

$( '#my-form .btn.previous-page' )
    .off( '.pagemode' )
    .on( 'click.pagemode', function() {
        window.history.back();
        return false;
    } );
```
* we are hiding the `skip to start` and `skip to end` buttons; it's not clear how history would work if these buttons were available