### PR TITLE
Remove no-op assignments from widgets

### DIFF
--- a/src/widget/analog-scale/analog-scalepicker.js
+++ b/src/widget/analog-scale/analog-scalepicker.js
@@ -208,7 +208,7 @@ define( function( require, exports, module ) {
             options = options || {};
 
             if ( !data && typeof options === 'object' ) {
-                $this.data( pluginName, ( data = new Analogscalepicker( this, options, event ) ) );
+                $this.data( pluginName, new Analogscalepicker( this, options, event ) );
             } else if ( data && typeof options === 'string' ) {
                 //pass the context, used for destroy() as this method is called on a cloned widget
                 data[ options ]( this );

--- a/src/widget/date/datepicker-extended.js
+++ b/src/widget/date/datepicker-extended.js
@@ -180,7 +180,7 @@ define( function( require, exports, module ) {
              */
 
             if ( !data && typeof options === 'object' && ( !options.touch || !support.inputtypes.date || badSamsung.test( navigator.userAgent ) ) ) {
-                $this.data( pluginName, ( data = new DatepickerExtended( this, options, event ) ) );
+                $this.data( pluginName, new DatepickerExtended( this, options, event ) );
             }
             //only call method if widget was instantiated before
             else if ( data && typeof options === 'string' ) {

--- a/src/widget/datetime/datetimepicker-extended.js
+++ b/src/widget/datetime/datetimepicker-extended.js
@@ -196,7 +196,7 @@ define( function( require, exports, module ) {
                 webview: "Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GT-P3100 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30" 
                 */
             if ( !data && typeof options === 'object' && ( !options.touch || !support.inputtypes.datetime || badSamsung.test( navigator.userAgent ) ) ) {
-                $this.data( pluginName, ( data = new DatetimepickerExtended( this, options, event ) ) );
+                $this.data( pluginName, new DatetimepickerExtended( this, options, event ) );
             }
             //only call method if widget was instantiated before
             else if ( data && typeof options === 'string' ) {

--- a/src/widget/distress/distresspicker.js
+++ b/src/widget/distress/distresspicker.js
@@ -117,7 +117,7 @@ define( function( require, exports, module ) {
             options = options || {};
 
             if ( !data && typeof options === 'object' ) {
-                $this.data( pluginName, ( data = new Distresspicker( this, options, event ) ) );
+                $this.data( pluginName, new Distresspicker( this, options, event ) );
             } else if ( data && typeof options === 'string' ) {
                 //pass the context, used for destroy() as this method is called on a cloned widget
                 data[ options ]( this );

--- a/src/widget/file/filepicker.js
+++ b/src/widget/file/filepicker.js
@@ -197,7 +197,7 @@ define( function( require, exports, module ) {
 
             //only instantiate if options is an object (i.e. not a string) and if it doesn't exist already
             if ( !data && typeof options === 'object' ) {
-                $this.data( pluginName, ( data = new Filepicker( this, options, event ) ) );
+                $this.data( pluginName, new Filepicker( this, options, event ) );
             }
             //only call method if widget was instantiated before
             else if ( data && typeof options === 'string' ) {

--- a/src/widget/geo/geopicker.js
+++ b/src/widget/geo/geopicker.js
@@ -1401,7 +1401,7 @@ define( function( require, exports, module ) {
                 options = options || {};
 
                 if ( !data && typeof options === 'object' ) {
-                    $this.data( pluginName, ( data = new Geopicker( this, options, event ) ) );
+                    $this.data( pluginName, new Geopicker( this, options, event ) );
                 } else if ( data && typeof options === 'string' ) {
                     //pass the context, used for destroy() as this method is called on a cloned widget
                     data[ options ]( this );

--- a/src/widget/horizontal-choices/horizontalchoices.js
+++ b/src/widget/horizontal-choices/horizontalchoices.js
@@ -69,7 +69,7 @@ define( function( require, exports, module ) {
 
             //only instantiate if options is an object (i.e. not a string) and if it doesn't exist already
             if ( !data && typeof options === 'object' ) {
-                $this.data( pluginName, ( data = new HorizontalChoices( this, options, event ) ) );
+                $this.data( pluginName, new HorizontalChoices( this, options, event ) );
             }
             //only call method if widget was instantiated before
             else if ( data && typeof options === 'string' ) {

--- a/src/widget/note/notewidget.js
+++ b/src/widget/note/notewidget.js
@@ -67,7 +67,7 @@ define( function( require, exports, module ) {
             options = options || {};
 
             if ( !data && typeof options === 'object' ) {
-                $this.data( pluginName, ( data = new Notewidget( this, options, event ) ) );
+                $this.data( pluginName, new Notewidget( this, options, event ) );
             } else if ( data && typeof options === 'string' ) {
                 data[ options ]( this );
             }

--- a/src/widget/radio/radiopicker.js
+++ b/src/widget/radio/radiopicker.js
@@ -122,7 +122,7 @@ define( function( require, exports, module ) {
         options = options || {};
 
         if ( !data && typeof options === 'object' ) {
-            $this.data( pluginName, ( data = new Radiopicker( $this[ 0 ], options, event ) ) );
+            $this.data( pluginName, new Radiopicker( $this[ 0 ], options, event ) );
         } else if ( data && typeof options === 'string' ) {
             data[ options ]( this );
         }

--- a/src/widget/select-desktop-bootstrap/selectpicker.js
+++ b/src/widget/select-desktop-bootstrap/selectpicker.js
@@ -238,7 +238,7 @@ define( function( require, exports, module ) {
 
             //only instantiate if options is an object AND if options.touch is falsy
             if ( !data && typeof options === 'object' && !options.touch ) {
-                $this.data( pluginName, ( data = new DesktopSelectpicker( this, options, event ) ) );
+                $this.data( pluginName, new DesktopSelectpicker( this, options, event ) );
             } else if ( data && typeof options === 'string' ) {
                 data[ options ]( this );
             }

--- a/src/widget/select-desktop/selectpicker.js
+++ b/src/widget/select-desktop/selectpicker.js
@@ -382,7 +382,7 @@ define( function( require, exports, module ) {
                 var data = $this.data( 'bs.dropdown' );
 
                 if ( !data ) {
-                    $this.data( 'bs.dropdown', ( data = new Dropdown( this ) ) );
+                    $this.data( 'bs.dropdown', new Dropdown( this ) );
                 }
                 if ( typeof option === 'string' ) {
                     data[ option ].call( $this );

--- a/src/widget/select-mobile/selectpicker.js
+++ b/src/widget/select-mobile/selectpicker.js
@@ -91,7 +91,7 @@ define( function( require, exports, module ) {
 
             //only instantiate if options is an object AND if options.touch is truthy
             if ( !data && typeof options === 'object' && options.touch ) {
-                $this.data( pluginName, ( data = new MobileSelectpicker( this, options, event ) ) );
+                $this.data( pluginName, new MobileSelectpicker( this, options, event ) );
             }
             if ( data && typeof options === 'string' ) {
                 data[ options ]( this );

--- a/src/widget/time/timepicker-extended.js
+++ b/src/widget/time/timepicker-extended.js
@@ -102,7 +102,7 @@ define( function( require, exports, module ) {
                 data = $this.data( pluginName );
 
             if ( !data && typeof options === 'object' && ( !options.touch || !support.inputtypes.time ) ) {
-                $this.data( pluginName, ( data = new TimepickerExtended( this, options, event ) ) );
+                $this.data( pluginName, new TimepickerExtended( this, options, event ) );
             }
             //only call method if widget was instantiated before
             else if ( data && typeof options === 'string' ) {


### PR DESCRIPTION
Looks like `data` is not used again after it was reassigned.