### PR TITLE
Scroll repeating element into view when it is added

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -348,7 +348,17 @@ define( function( require, exports, module ) {
                         that.updateAllActive();
                         // removing the class in effect avoids the animation
                         $( event.target ).removeClass( 'current contains-current' ).find( '.current' ).removeClass( 'current' );
+
+                        // TODO we should only force a page-change if required -
+                        // this call instantly scrolls to the top of the page
+                        // even if we were already on the correct page, which is
+                        // disorientating users.
                         that.flipToPageContaining( $( event.target ) );
+
+                        // Make sure that the newly-added fields are actually
+                        // visible.  This may be unnecessary when page-flipping
+                        // is fixed (above).
+                        event.target.scrollIntoView();
                     } )
                     .off( 'removerepeat.pagemode' )
                     .on( 'removerepeat.pagemode', function( event ) {


### PR DESCRIPTION
Issues: #356 medic/medic-webapp#1588

I wrote this fix a while back, and on reviewing, I suspect the TODO could be removed - it's likely that the `scrollIntoView()` call is useful whether the new elements are on the same page or not.