### PR TITLE
Make the root URL of demo server serve the demo page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,8 @@ module.exports = function( grunt ) {
         connect: {
             server: {
                 options: {
-                    port: 8005
+                    port: 8005,
+                    base: ['forms', 'build']
                 }
             },
             test: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,7 @@ module.exports = function( grunt ) {
             server: {
                 options: {
                     port: 8005,
-                    base: ['forms', 'build']
+                    base: [ 'forms', 'build' ]
                 }
             },
             test: {

--- a/forms/index.html
+++ b/forms/index.html
@@ -4,13 +4,13 @@
 		<title>Enketo-Core Developer template</title>
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,600&amp;subset=latin,cyrillic-ext,cyrillic,greek-ext,greek,vietnamese,latin-ext' rel='stylesheet' type='text/css'>
 
-		<!--<link type="text/css" href="../build/css/plain.css" media="all" rel="stylesheet" />-->
-		<link type="text/css" href="../build/css/formhub.css" media="all" rel="stylesheet" />
-		<!--<link type="text/css" href="../build/css/grid.css" media="all" rel="stylesheet" />-->
+		<!--<link type="text/css" href="./css/plain.css" media="all" rel="stylesheet" />-->
+		<link type="text/css" href="./css/formhub.css" media="all" rel="stylesheet" />
+		<!--<link type="text/css" href="./css/grid.css" media="all" rel="stylesheet" />-->
 
-		<!--<link type="text/css" href="../build/css/plain-print.css" media="print" rel="stylesheet" />-->
-		<link type="text/css" href="../build/css/formhub-print.css" media="print" rel="stylesheet" />
-		<!--<link type="text/css" href="../build/css/grid-print.css" media="print" rel="stylesheet" />-->
+		<!--<link type="text/css" href="./css/plain-print.css" media="print" rel="stylesheet" />-->
+		<link type="text/css" href="./css/formhub-print.css" media="print" rel="stylesheet" />
+		<!--<link type="text/css" href="./css/grid-print.css" media="print" rel="stylesheet" />-->
 
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		
@@ -73,6 +73,6 @@
 		<!-- <script src="//localhost:35729/livereload.js"></script> -->
 		
 		<!-- all the scripts -->
-		<script type="text/javascript"  src="../build/js/enketo-bundle.js"></script>
+		<script type="text/javascript"  src="./js/enketo-bundle.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Not sure if there's a technical reason for the current config, but this seems more convenient for dev use - open the browser to the address mentioned below (`http://localhost:8005`), and you immediately get the form demo page:

```
Running "concurrent:develop" (concurrent) task
    Running "watch" task
    Waiting...
    Running "shell:transformer" (shell) task
    Running "connect:server:keepalive" (connect) task
    Waiting forever...
    Started connect web server on http://localhost:8005
    app running on port 8085!
```