### PR TITLE
Reference the translator module consistently from widgets and Form.js

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -26,7 +26,7 @@ define( function( require, exports, module ) {
     var $ = require( 'jquery' );
     var Promise = require( 'lie' );
     var utils = require( './utils' );
-    var t = require( './fake-translator' ).t;
+    var t = require( 'translator' ).t;
     var pkg = require( '../../package' );
     var config = require( 'text!enketo-config' );
     require( './plugins' );


### PR DESCRIPTION
Make references to `translator` consistent.

Ideally though, all code would probably refer to `fake-translator`, and leave this up to 3rd-parties to override with their own translator using e.g. browserify.