### PR TITLE
Trigger calcUpdate() calls for changes to option labels

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -1418,6 +1418,13 @@ define( function( require, exports, module ) {
                 }
                 if ( $output.text() !== val ) {
                     $output.text( val );
+
+                    // For <output>s that are children of choice-groups, trigger
+                    // dependent calculations in case one is using a jr:choice-name.
+                    var owName = $output.closest( '.option-wrapper' ).find( 'input' ).attr( 'name' );
+                    if ( owName ) {
+                        that.calcUpdate( owName.substring( owName.indexOf( '/', 1 ) ) );
+                    }
                 }
             } );
         };


### PR DESCRIPTION
Fixes #412 

This is a fix for the example form shown in #412

I'm not convinced this is safe or optimal for a few reasons:
* there may be other types of choice which are supported by `jr:choice-name`, but don't use `.option-wrapper`
* I'm not 100% certain how the string passed to `calcUpdate()` should be calculated, but cutting the form name off the front of the fully-qualified xpath to the model element seems to work (`owName.substring( owName.indexOf( '/', 1 ) )`)
* there _may_ be cases when an `<output>` can occur within `.option-wrapper` but outside an option label, in which case `calcUpdate()` will be triggered needlessly

Perhaps if nothing else, this fix will give a clearer insight into what the bug in #410 really is!
