### PR TITLE
Force timezone when running karma tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ addons:
 before_script:
   - npm install -g grunt-cli
 before_install:
-  - export TZ=America/Denver
   - date

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -2,6 +2,10 @@
 // Generated on Mon Mar 16 2015 13:42:33 GMT-0600 (MDT)
 
 module.exports = function( config ) {
+
+    // Force timezone for tests, so that datetime conversion results are predictable
+    process.env.TZ = 'America/Denver';
+
     config.set( {
 
         // base path that will be used to resolve all patterns (eg. files, exclude)


### PR DESCRIPTION
Move timezone configuration from Travis config to karma config.  This should allow tests to pass with `npm test` on any machine.