### PR TITLE
Add support for `tel` input type in clearInputs()

### DIFF
--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -38,6 +38,7 @@ $.fn.clearInputs = function( ev1, ev2 ) {
                 case 'email':
                 case 'password':
                 case 'text':
+                case 'tel':
                 case 'file':
                     $node.removeAttr( 'data-previous-file-name data-loaded-file-name' );
                     /* falls through */


### PR DESCRIPTION
Add support for clearing HTML `tel` inputs.  This means that if e.g. a widget changes an `<input type="text">` to `<input type="tel">`, the input will clear properly.