### PR TITLE
Don't do file-specific work for other types of input

### DIFF
--- a/src/js/plugins.js
+++ b/src/js/plugins.js
@@ -27,6 +27,9 @@ $.fn.clearInputs = function( ev1, ev2 ) {
                 type = 'textarea';
             }
             switch ( type ) {
+                case 'file':
+                    $node.removeAttr( 'data-previous-file-name data-loaded-file-name' );
+                    /* falls through */
                 case 'date':
                 case 'datetime':
                 case 'time':
@@ -38,9 +41,6 @@ $.fn.clearInputs = function( ev1, ev2 ) {
                 case 'email':
                 case 'password':
                 case 'text':
-                case 'file':
-                    $node.removeAttr( 'data-previous-file-name data-loaded-file-name' );
-                    /* falls through */
                 case 'hidden':
                 case 'textarea':
                     if ( $node.val() !== '' ) {


### PR DESCRIPTION
There might be a subtle reason (e.g. browser compatibility) why the code was written like it was, but it seems like you shouldn't need to handle the `data-previous-file-name` `data-loaded-file-name` attributes on input types which are not `type="file"`