### PR TITLE
Make jr:choice-name() regex more foolproof

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -285,11 +285,11 @@ Form.prototype.replaceChoiceNameFn = function( expr, resTypeStr, selector, index
     var name;
     var $input;
     var label = '';
-    var matches = expr.match( /jr:choice-name\(([^,]+),\s?'(.*?)'\)/ );
+    var matches = expr.match( /jr:choice-name\(\s*([^,]*[^,\s])\s*,\s*'([^']*)'\s*\)/ );
 
     if ( matches ) {
         value = this.model.evaluate( matches[ 1 ], resTypeStr, selector, index, tryNative );
-        name = matches[ 2 ].trim();
+        name = matches[ 2 ];
         $input = this.view.$.find( '[name="' + name + '"]' );
 
         if ( $input.length > 0 && $input.prop( 'nodeName' ).toLowerCase() === 'select' ) {


### PR DESCRIPTION
I'm not sure how important this is, but the old regex would not match a string like:
```
var expr = 'jr:choice-name( /something[@some_attr="val with space"] , \'/something\' )';
console.log('old', expr.match( /jr:choice-name\(([^,]+),\s?'(.*?)'\)/ ));
console.log('new', expr.match( /jr:choice-name\(\s*([^,]*[^,\s])\s*,\s*'([^']*)'\s*\)/ ));
```
I can't see any specific tests for this function, but could cook some up if that would be helpful.