### PR TITLE
Remove unused argument

### DIFF
--- a/src/widget/file/filepicker.js
+++ b/src/widget/file/filepicker.js
@@ -138,7 +138,7 @@ Filepicker.prototype._changeListener = function() {
             fileName = utils.getFilename( file, postfix );
 
             // process the file
-            fileManager.getFileUrl( file, fileName )
+            fileManager.getFileUrl( file )
                 .then( function( url ) {
                     // update UI
                     that._showPreview( url, that.props.mediaType );


### PR DESCRIPTION
Doesn't look like the second arg is used.  If it's being used by dependent projects, we should document that in `file-manager`.