### PR TITLE
Expose file-manager.isTooLarge()

### DIFF
--- a/src/js/file-manager.js
+++ b/src/js/file-manager.js
@@ -60,7 +60,7 @@ function getFileUrl( subject ) {
             // TODO obtain from storage
             reject( 'no!' );
         } else if ( typeof subject === 'object' ) {
-            if ( _isTooLarge( subject ) ) {
+            if ( module.exports.isTooLarge( subject ) ) {
                 error = new Error( 'File too large' );
                 reject( error );
             } else {
@@ -158,7 +158,7 @@ function _dataUriToBlob( dataURI ) {
  * @param  {Blob}  file [description]
  * @return {Boolean}      [description]
  */
-function _isTooLarge( file ) {
+function isTooLarge( file ) {
     return false;
 }
 
@@ -168,5 +168,6 @@ module.exports = {
     isWaitingForPermissions: isWaitingForPermissions,
     init: init,
     getFileUrl: getFileUrl,
-    getCurrentFiles: getCurrentFiles
+    getCurrentFiles: getCurrentFiles,
+    isTooLarge: isTooLarge
 };


### PR DESCRIPTION
Closes #465 

This does the job, but referencing `module.exports` internally is perhaps a bit ugly, and isn't a pattern used elsewhere in the project.

Would it be preferable to create a `FileManager` class?  Some thoughts:
* `fileManager.init()` could remain as a factory method for overriding as required
* `fileManager.getCurrentFiles()` appears to be a "static" method anyway, and only used for debug
* instead of overriding `require('./file-manager').isTooLarge`, you would then override `require('./file-manager').prototype.isTooLarge`

I'll give the above a quick fiddle and see if it works easily 🙂 