### PR TITLE
Test on travis on more node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 language: node_js
 node_js:
-  - "6"
+  - lts/*
 addons:
   apt:
     packages:


### PR DESCRIPTION
Is there any value to testing against a specific version?  If not, then maybe we should switch from `6` to long term support (`lts/*`) or latest stable (`node`).  Or perhaps supporting a very old version will make browser compatibility a bit safer.  Any thoughts?