### PR TITLE
Handle complex jr:choice-name() better

### DIFF
--- a/src/js/Form.js
+++ b/src/js/Form.js
@@ -292,8 +292,8 @@ Form.prototype.replaceChoiceNameFn = function( expr, resTypeStr, selector, index
     var $input;
     var label = '';
     var matches = expr.match( new RegExp( 'jr:choice-name\\(([^,]+),\\s*(?:' +
-        '"(.*)"|' +
-        "'(.*)'" +
+        '"([^"]*)"|' +
+        "'([^']*)'" +
         ')\\s*\\)' ) );
 
     if ( matches ) {

--- a/test/forms/jr-choice-name.issue-490.xml
+++ b/test/forms/jr-choice-name.issue-490.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <h:head>
+    <h:title>Test Issue 490 - jr:choice-name()</h:title>
+    <model>
+      <instance>
+        <embedded-choice delimiter="#" id="issue_490" prefix="J1!issue_490!" version="2017-12-22">
+          <translator></translator><output/><debug/>
+          <meta>
+            <instanceID/>
+          </meta>
+        </embedded-choice>
+      </instance>
+      <bind nodeset="/embedded-choice/translator" type="select1"/>
+      <bind calculate="if(string-length( /embedded-choice/translator ) !=0, jr:choice-name( /embedded-choice/translator ,' /embedded-choice/translator '),'unspecified')" nodeset="/embedded-choice/output" type="string"/>
+      <bind nodeset="/embedded-choice/debug" readonly="true()" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/embedded-choice/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <select1 ref="/embedded-choice/translator">
+      <label>Translator</label>
+      <item>
+        <label>District</label>
+        <value>district_hospital</value>
+      </item>
+      <item>
+        <label>Health Center</label>
+        <value>health_center</value>
+      </item>
+      <item>
+        <label>Area</label>
+        <value>clinic</value>
+      </item>
+    </select1>
+    <input ref="/embedded-choice/debug">
+      <label><output value=" /embedded-choice/output "/></label>
+    </input>
+  </h:body>
+</h:html>


### PR DESCRIPTION
Fix regression in jr:choice-name() when the function call is embedded within
other function calls.

Closes #490 

@MartijnR I'm not really happy with either of the new tests supplied here:

1. the mocking required for the "unit" test is horrible
2. the integration test is probably better, but it seems a bit much that we have to include a new form just to test changes to a regex

One option to clean things up would be to expose the regex somehow, e.g. include it in a different file and `require(…)` it into both `Form.js` and a test file.  Seems a bit extreme to have a separate file for a single regex, though.

But if you're happy with the PR as-is, please merge.