### PR TITLE
[DNM] changed: first try replacing the xpath-evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8123,6 +8123,11 @@
                 "lodash.toarray": "^4.4.0"
             }
         },
+        "node-forge": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+            "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+        },
         "node-gyp": {
             "version": "3.8.0",
             "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
@@ -8478,6 +8483,14 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
+            }
+        },
+        "openrosa-xpath-evaluator": {
+            "version": "2.0.0-beta.3",
+            "resolved": "https://registry.npmjs.org/openrosa-xpath-evaluator/-/openrosa-xpath-evaluator-2.0.0-beta.3.tgz",
+            "integrity": "sha512-OZBY/k6AtC62lrsdYDEe3XxPirOWnud9mw7khGLNkC9zDH9VBROdqAsAT7pgQKfQsQIAOJeFZFZmi2HqHkXOBw==",
+            "requires": {
+                "node-forge": "^0.9.0"
             }
         },
         "opn": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
         "leaflet-draw": "github:enketo/Leaflet.draw#ff73078",
         "leaflet.gridlayer.googlemutant": "0.8.x",
         "mergexml": "1.2.1",
+        "openrosa-xpath-evaluator": "^2.0.0-beta.3",
         "signature_pad": "2.3.x"
     }
 }

--- a/src/js/xpath-evaluator-binding.js
+++ b/src/js/xpath-evaluator-binding.js
@@ -1,12 +1,10 @@
-import XPathJS from 'enketo-xpathjs';
+import orxe from 'openrosa-xpath-evaluator';
 
 /**
  * @function xpath-evaluator-binding
  * @param {Function} addExtensions
  */
 export default function( addExtensions ) {
-    const evaluator = new XPathJS.XPathEvaluator();
-
     /*
      * Note: it's inefficient to extend XPathJS here (for every model instance)
      * instead of just once in the prototype.
@@ -21,27 +19,8 @@ export default function( addExtensions ) {
      * and leave the addExtensions parameter empty here.
      */
     if ( typeof addExtensions === 'function' ) {
-        addExtensions( XPathJS );
+        addExtensions( orxe );
     }
 
-    XPathJS.bindDomLevel3XPath( this.xml, {
-        'window': {
-            JsXPathException: true,
-            JsXPathExpression: true,
-            JsXPathNSResolver: true,
-            JsXPathResult: true,
-            JsXPathNamespace: true
-        },
-        'document': {
-            jsCreateExpression( ...args ) {
-                return evaluator.createExpression( ...args );
-            },
-            jsCreateNSResolver( ...args ) {
-                return evaluator.createNSResolver( ...args );
-            },
-            jsEvaluate( ...args ) {
-                return evaluator.evaluate( ...args );
-            }
-        }
-    } );
+    orxe.bindDomLevel3XPath( this.xml );
 }


### PR DESCRIPTION
Hi @vimemo,

I got a little excited and wanted to see how your new evaluator worked in Enketo Core.

There are some failing tests in Enketo Core. From a first glance it looks like most (or all) are related to XPathResult data types. And maybe some to some more complex internal XPath queries. I'll look further, but I wanted to quickly share this already to see if you had the same idea about the method of replacing enketo-xpathjs (and maybe you've already tried this yourself).

It's a bit messy due to the whitespace changes, but the main change is in xpath-evaluator-binding.js. Does that way of binding seem correct? (not urgent)

I also understood that we can no longer rename the custom evaluate function (to e.g. jsEvaluate as we had before). I think that's fine if the new evaluator is nearly as fast for purely native XPath expressions. It will simplify the code in enketo-core.

Cheers,

