### PR TITLE
Fixed: default value not work for datetime with midnight value, complete the fix of #665

### DIFF
--- a/src/js/input.js
+++ b/src/js/input.js
@@ -265,8 +265,8 @@ export default {
                         value = new Date( value ).toISOLocalString();
                         // chop off local timezone offset to display properly in (native datetime-local) widget
                         const parts = value.split( 'T' );
-                        const date = parts[0];
-                        const time = ( parts && parts[ 1 ] ) ? parts[ 1 ].split(/[Z\-+]/)[0] : '00:00';
+                        const date = parts[ 0 ];
+                        const time = ( parts && parts[ 1 ] ) ? parts[ 1 ].split( /[Z\-+]/ )[ 0 ] : '00:00';
                         value = `${date}T${time}`;
                     }
                 }

--- a/src/js/input.js
+++ b/src/js/input.js
@@ -265,7 +265,9 @@ export default {
                         value = new Date( value ).toISOLocalString();
                         // chop off local timezone offset to display properly in (native datetime-local) widget
                         const parts = value.split( 'T' );
-                        value = `${parts[0]}T${parts[1].split(/[Z\-+]/)[0]}`;
+                        const date = parts[0];
+                        const time = ( parts && parts[ 1 ] ) ? parts[ 1 ].split(/[Z\-+]/)[0] : '00:00';
+                        value = `${date}T${time}`;
                     }
                 }
             }

--- a/src/widget/time/timepicker.js
+++ b/src/widget/time/timepicker.js
@@ -873,7 +873,9 @@ import event from '../../js/event';
                 if ( this.showMeridian ) {
                     if ( hour >= 12 ) {
                         // Force PM.
-                        timeMode = 2;
+                        if ( !timeMode ) {
+                            timeMode = 2;
+                        }
                         hour -= 12;
                     }
                     if ( !timeMode ) {


### PR DESCRIPTION
Fixed:

- #649 default value not work for datetime with midnight value, it's a regression after 5.9.0.
- new issue introdueced by  #665.