### PR TITLE
fixed: OC: Print CRF/Casebook PDF long string(s) in text field overlaps

### DIFF
--- a/src/sass/core/_print.scss
+++ b/src/sass/core/_print.scss
@@ -455,3 +455,24 @@ h4 {
         }
     }
 }
+
+.or-text-print-initialized {
+    input {
+        &[type=text] {
+            display: none;
+        }
+    }
+
+    .print-input-text {
+        font-weight: normal;
+        font-size: 12px;
+        width: 80%;
+        padding: 6px 12px;
+        border-bottom: 1px solid black;
+    }
+
+    .print-only {
+        display: inline-block;
+        page-break-inside: avoid;
+    }
+}

--- a/src/sass/grid/_print.scss
+++ b/src/sass/grid/_print.scss
@@ -222,3 +222,13 @@ screen and (min-width: 700px) {
 }
 
 // End of adjustment to get page breaks to work in multi-line flexbox
+
+// text-print widget
+.or-text-print-initialized {
+    .print-input-text {
+        width: 100%;
+        padding-left: 0;
+        padding-right: 0;
+        border-bottom: none;
+    }
+}

--- a/src/sass/grid/_widgets.scss
+++ b/src/sass/grid/_widgets.scss
@@ -232,15 +232,3 @@ legend .btn-comment {
 .or-appearance-distress .range-widget__wrap {
     margin-top: 0;
 }
-
-// text-print widget
-@media print {
-    .or-text-print-initialized {
-        .print-input-text {
-            width: 100%;
-            padding-left: 0;
-            padding-right: 0;
-            border-bottom: none;
-        }
-    }
-}

--- a/src/widget/text-print/text-print.scss
+++ b/src/widget/text-print/text-print.scss
@@ -1,21 +1,3 @@
-@media print {
-    .or-text-print-initialized {
-        input {
-            &[type=text] {
-                display: none;
-            }
-        }
-
-        .print-input-text {
-            font-weight: normal;
-            font-size: 12px;
-            width: 80%;
-            padding: 6px 12px;
-            border-bottom: 1px solid black;
-        }
-    }
-}
-
 @media screen {
     .or-text-print-initialized {
         .print-only {


### PR DESCRIPTION
#166 
[OC-12196](https://jira.openclinica.com/browse/OC-12196)
example:
[Vital Signs-long-text-single-line.pdf](https://github.com/enketo/enketo-core/files/4152109/Vital.Signs-long-text-single-line.pdf)
