### PR TITLE
fixed: PDF endpoint creates image-map that overlaps in cell below with Grid theme

### DIFF
--- a/src/js/print.js
+++ b/src/js/print.js
@@ -204,8 +204,12 @@ function _resizeRowElements( row, maxWidth ) {
     } );
 
     row.forEach( el => {
-        el.classList.add( 'print-height-adjusted' );
-        el.style.height = `${maxHeight}px`;
+        // unset max height for image-map widget 
+        // (https://github.com/OpenClinica/enketo-express-oc/issues/363)
+        if ( !el.classList.contains( 'or-appearance-image-map' ) ) {
+            el.classList.add( 'print-height-adjusted' );
+            el.style.height = `${maxHeight}px`;
+        }
     } );
 }
 


### PR DESCRIPTION
[#363](https://github.com/OpenClinica/enketo-express-oc/issues/363)