### PR TITLE
fixed: Form Printing adding page breaks in the middle of an item

### DIFF
--- a/src/sass/grid/_print.scss
+++ b/src/sass/grid/_print.scss
@@ -225,3 +225,15 @@ screen and (min-width: 700px) {
 }
 
 // End of adjustment to get page breaks to work in multi-line flexbox
+
+// Another workaround to get page breaks to works
+// https://github.com/OpenClinica/enketo-express-oc/issues/463
+.or {
+    &:not(.print-relevant-only) section.question.or-branch.disabled, 
+    &:not(.print-relevant-only) section.or-branch.disabled,
+    &:not(.print-relevant-only) section.question.or-branch:not(.disabled):not(.pre-init), 
+    &:not(.print-relevant-only) section.or-branch:not(.disabled):not(.pre-init) {
+        display: table;
+        break-inside: avoid;
+    }
+}


### PR DESCRIPTION
[#463](https://github.com/OpenClinica/enketo-express-oc/issues/463)

Using this XML [PostSurgery.xml.txt](https://github.com/enketo/enketo-core/files/6229185/PostSurgery.xml.txt) for testing also added `break-inside: avoid;` to make sure the header(title) move to the next pages too(when page breaks triggered).
