### PR TITLE
Implement odk:setgeopoint for odk-instance-first-load events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 language: node_js
 node_js:
   - "12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1541,8 +1541,9 @@
             }
         },
         "enketo-transformer": {
-            "version": "git+https://github.com/eyelidlessness/enketo-transformer.git#1617062af95e02544b051bdbd9199a8c93b0ea73",
-            "from": "git+https://github.com/eyelidlessness/enketo-transformer.git#1617062",
+            "version": "1.43.0",
+            "resolved": "https://registry.npmjs.org/enketo-transformer/-/enketo-transformer-1.43.0.tgz",
+            "integrity": "sha512-9iel+sgSIA13GQ1n/xQLJiXjRSBWEP4yWuT9u9Q60mBz4WRAFL3BVk+oAdB5Sbytc2D8p4cgL2xhQUwKulPWOQ==",
             "dev": true,
             "requires": {
                 "body-parser": "1.19.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1541,9 +1541,8 @@
             }
         },
         "enketo-transformer": {
-            "version": "1.42.0",
-            "resolved": "https://registry.npmjs.org/enketo-transformer/-/enketo-transformer-1.42.0.tgz",
-            "integrity": "sha512-XJsjNDvd68lHbtRvc8/jlDgs1ywPG/IQ+pPLOwBoHL5TzUjKleS33ufYO8cDkrF3xGrStPrmtx6PYDIoPTIjWw==",
+            "version": "git+https://github.com/eyelidlessness/enketo-transformer.git#1617062af95e02544b051bdbd9199a8c93b0ea73",
+            "from": "git+https://github.com/eyelidlessness/enketo-transformer.git#1617062",
             "dev": true,
             "requires": {
                 "body-parser": "1.19.x",
@@ -3314,9 +3313,9 @@
             "dev": true
         },
         "ignore-walk": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-            "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
+            "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
             "dev": true,
             "requires": {
                 "minimatch": "^3.0.4"
@@ -5182,9 +5181,9 @@
             "dev": true
         },
         "npm-bundled": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-            "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
+            "integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
             "dev": true,
             "requires": {
                 "npm-normalize-package-bin": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "devDependencies": {
         "cross-env": "^7.0.3",
         "docdash": "^1.2.0",
-        "enketo-transformer": "https://github.com/eyelidlessness/enketo-transformer.git#1617062",
+        "enketo-transformer": "1.43.0",
         "eslint-plugin-jsdoc": "^32.3.0",
         "grunt": "^1.3.0",
         "grunt-concurrent": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "devDependencies": {
         "cross-env": "^7.0.3",
         "docdash": "^1.2.0",
-        "enketo-transformer": "1.42.0",
+        "enketo-transformer": "https://github.com/eyelidlessness/enketo-transformer.git#1617062",
         "eslint-plugin-jsdoc": "^32.3.0",
         "grunt": "^1.3.0",
         "grunt-concurrent": "^3.0.0",

--- a/src/js/calculate.js
+++ b/src/js/calculate.js
@@ -246,6 +246,7 @@ export default {
 
         const newModelValue = props.dataNodesObj.getVal();
 
+        // This is okay for an xforms-value-changed action (may be no form control)
         if ( !control ) {
             return;
         }
@@ -264,9 +265,6 @@ export default {
             if ( control.type !== 'hidden' && config.validateContinuously === true ) {
                 this.form.validateInput( control );
             }
-        } else {
-            // This is okay for an xforms-value-changed action (may be no form control)
-            // console.log( 'no form control found' );
         }
     },
 

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -1188,6 +1188,6 @@ Form.prototype.goToTarget = function( target ) {
  * @type {string}
  * @default
  */
-Form.requiredTransformerVersion = 'https://github.com/eyelidlessness/enketo-transformer.git#1617062';
+Form.requiredTransformerVersion = '1.43.0';
 
 export { Form, FormModel };

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -250,7 +250,7 @@ Form.prototype.init = function() {
     } );
 
     // Before initializing form view and model, passthrough some model events externally
-    // Because of setvalue/instance-first-load, this should be done before the model is initialized. This is important for custom
+    // Because of instance-first-load actions, this should be done before the model is initialized. This is important for custom
     // applications that submit each individual value separately (opposed to a full XML model at the end).
     this.model.events.addEventListener( events.DataUpdate().type, event => {
         that.view.html.dispatchEvent( events.DataUpdate( event.detail ) );

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -232,13 +232,22 @@ Form.prototype.init = function() {
     this.readonly = this.addModule( readonlyModule );
 
     // Handle odk-instance-first-load event
-    this.model.events.addEventListener( events.InstanceFirstLoad().type, event => this.calc.setValue( event ) );
+    this.model.events.addEventListener( events.InstanceFirstLoad().type, event => {
+        this.calc.performAction( 'setvalue', event );
+        this.calc.performAction( 'setgeopoint', event );
+    } );
 
     // Handle odk-new-repeat event before initializing repeats
-    this.view.html.addEventListener( events.NewRepeat().type, event => this.calc.setValue( event ) );
+    this.view.html.addEventListener( events.NewRepeat().type, event => {
+        this.calc.performAction( 'setvalue', event );
+        this.calc.performAction( 'setgeopoint', event );
+    } );
 
     // Handle xforms-value-changed
-    this.view.html.addEventListener( events.XFormsValueChanged().type, event => this.calc.setValue( event ) );
+    this.view.html.addEventListener( events.XFormsValueChanged().type, event => {
+        this.calc.performAction( 'setvalue', event );
+        this.calc.performAction( 'setgeopoint', event );
+    } );
 
     // Before initializing form view and model, passthrough some model events externally
     // Because of setvalue/instance-first-load, this should be done before the model is initialized. This is important for custom
@@ -1151,7 +1160,7 @@ Form.prototype.goToTarget = function( target ) {
             this.pages.flipToPageContaining( $( target ) );
         }
         // check if the target has a form control
-        if ( target.closest( '.calculation, .setvalue' ) ) {
+        if ( target.closest( '.calculation, .setvalue, .setgeopoint' ) ) {
             // It is up to the apps to decide what to do with this event.
             target.dispatchEvent( events.GoToInvisible() );
         }
@@ -1179,6 +1188,6 @@ Form.prototype.goToTarget = function( target ) {
  * @type {string}
  * @default
  */
-Form.requiredTransformerVersion = '1.42.0';
+Form.requiredTransformerVersion = 'https://github.com/eyelidlessness/enketo-transformer.git#1617062';
 
 export { Form, FormModel };

--- a/src/js/geolocation.js
+++ b/src/js/geolocation.js
@@ -1,0 +1,31 @@
+/**
+ * @typedef GeolocationPosition
+ * @property {string} geopoint
+ * @property {number} lat
+ * @property {number} lng
+ * @property {window.GeolocationPosition} position
+ */
+
+/**
+ * @param {window.PositionOptions} [options] - lookup options
+ * @return {Promise<GeolocationPosition>} - coordinates
+ */
+export const getCurrentPosition = ( options ) => {
+    return new Promise( ( resolve, reject ) => {
+        navigator.geolocation.getCurrentPosition( ( position ) => {
+            const { latitude, longitude, altitude, accuracy } = position.coords;
+
+            const lat = Math.round( latitude * 1000000 ) / 1000000;
+            const lng = Math.round( longitude * 1000000 ) / 1000000;
+
+            const geopoint = `${lat} ${lng} ${altitude || '0.0'} ${accuracy || '0.0'}`;
+
+            resolve( {
+                geopoint,
+                lat,
+                lng,
+                position,
+            } );
+        }, reject, options );
+    } );
+};

--- a/src/js/input.js
+++ b/src/js/input.js
@@ -14,7 +14,7 @@ export default {
      * @return {Element} Wrap node
      */
     getWrapNode( control ) {
-        return control.closest( '.question, .calculation, .setvalue' );
+        return control.closest( '.question, .calculation, .setvalue, .setgeopoint' );
     },
     /**
      * @param {Array<Element>} controls - form controls HTML elements
@@ -209,7 +209,7 @@ export default {
         return value || '';
     },
     /**
-     * Finds a form control that is not a nested setvalue/xforms-value-changed directive
+     * Finds a form control that is not a nested xforms-value-changed action
      *
      * @param {string} name - name attribute value
      * @param {number} index - repeat index
@@ -342,7 +342,7 @@ export default {
                 // don't trigger on all radiobuttons/checkboxes
                 if ( event ) {
                     inputs[ 0 ].dispatchEvent( event );
-                    // Ensure that any calculations with form controls that serve as setvalue triggers
+                    // Ensure that any calculations with form controls that serve as action triggers
                     // the action.
                     if ( event.type === events.InputUpdate().type ){
                         inputs[0].dispatchEvent( events.XFormsValueChanged() );

--- a/src/js/readonly.js
+++ b/src/js/readonly.js
@@ -14,10 +14,10 @@ export default {
             node.closest( '.question' ).classList.add( 'readonly' );
 
             const path = this.form.input.getName( node );
-            const setValue = this.form.view.html.querySelector( `[data-setvalue][data-event="xforms-value-changed"][name="${path}"]` );
+            const action = this.form.view.html.querySelector( `[data-setvalue][data-event="xforms-value-changed"][name="${path}"], [data-setgeopoint][data-event="xforms-value-changed"][name="${path}"]` );
 
             // Note: the readonly-forced class is added for special readonly views of a form.
-            const empty = !node.value && !node.dataset.calculate && !setValue && !node.classList.contains( 'readonly-forced' );
+            const empty = !node.value && !node.dataset.calculate && !action && !node.classList.contains( 'readonly-forced' );
 
             node.classList.toggle( 'empty', empty );
 

--- a/test/forms/setgeopoint.xml
+++ b/test/forms/setgeopoint.xml
@@ -22,7 +22,7 @@
             <bind nodeset="/data/hidden_first_load" type="string"/>
             <bind nodeset="/data/visible_first_load" type="string"/>
 
-            <odk:setgeopoint event="odk-instance-first-load" ref="/data/hidden_first_load"/>
+            <odk:setgeopoint event="some-unsupported-event odk-instance-first-load" ref="/data/hidden_first_load"/>
         </model>
     </h:head>
     <h:body>

--- a/test/forms/setgeopoint.xml
+++ b/test/forms/setgeopoint.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>setgeopoint</h:title>
+        <model>
+            <instance>
+                <data id="setgeopoint">
+                    <hidden_first_load/>
+                    <visible_first_load/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/hidden_first_load" type="string"/>
+            <bind nodeset="/data/visible_first_load" type="string"/>
+
+            <odk:setgeopoint event="odk-instance-first-load" ref="/data/hidden_first_load"/>
+        </model>
+    </h:head>
+    <h:body>
+        <odk:setgeopoint event="odk-instance-first-load" ref="/data/visible_first_load"/>
+        <input ref="/data/visible_first_load">
+            <label>odk-instance-first-load</label>
+        </input>
+    </h:body>
+</h:html>

--- a/test/helpers/geolocation.js
+++ b/test/helpers/geolocation.js
@@ -1,0 +1,125 @@
+/**
+ * @typedef CoordinatesData
+ * @property {number} latitude
+ * @property {number} longitude
+ * @property {number} [altitude]
+ * @property {number} [accuracy]
+ */
+
+/**
+ * @typedef TestCoordinates
+ * @property {window.GeolocationCoordinates} [coordinates] - a GeolocationCoordinates instance
+ * @property {string} geopoint
+ */
+
+/**
+ * @param {CoordinatesData} coordinates - Coordinate data to populate a `GeolocationCoordinates` object
+ *
+ * @return {window.GeolocationCoordinates} - returns a TestCoordinates object
+ */
+export const createTestCoordinates = ( {
+    latitude,
+    longitude,
+    altitude = null,
+    accuracy = null,
+} ) => (
+    Object.create( window.GeolocationCoordinates.prototype, {
+        latitude: { value: latitude },
+        longitude: { value: longitude },
+        altitude: { value: altitude },
+        accuracy: { value: accuracy },
+        altitudeAccuracy: { value: null },
+        heading: { value: null },
+        speed: { value: null },
+    } )
+);
+
+/**
+ * @param {'PERMISSION_DENIED'|'POSITION_UNAVAILABLE'|'TIMEOUT'} reason - the reason a geolocation lookup failed
+ *
+ * @return {window.GeolocationPositionError} - a lookup error instance
+ */
+export const createGeolocationLookupError = ( reason ) => (
+    Object.create( window.GeolocationPositionError.prototype, {
+        code: { value: window.GeolocationPositionError[reason] },
+        message: { value: reason },
+    } )
+);
+
+/**
+ * @typedef MockGeolocationLookupOptions
+ * @property {boolean} [expectLookup] - if true, after each test in a suite where `mockGeolocationLookup` is called, the test will fail if it did not perform a lookup.
+ */
+
+/**
+ * Mocks geolocation lookups.
+ *
+ * If the provided `result` is a valid coordinate, a lookup will asynchronously call
+ * the `successCallback` provided to `Geolocation#getCurrentPosition` with that result.
+ *
+ * If `result` is a `GeolocationPositionError`, and if an `errorCallback` is provided,
+ * that callback will be called with the error.
+ *
+ * If the test completes and `Geolocation#getCurrentPosition` was not called, the test
+ * expecting a lookup will fail.
+ *
+ * @param {TestCoordinates | window.GeolocationPositionError} result - the result of a mocked geolocation lookup
+ * @param {MockGeolocationLookupOptions} [options] - options for mocking `Geolocation#getCurrentPosition`
+ *
+ * @return {{ lookup: Promise<{ geopoint: string }> }} - object containing `lookup` reference which,
+ * if a geolocation lookup is performed, will be a promise that resolves with the
+ * expected geopoint value when the lookup is complete.
+ */
+export const mockGetCurrentPosition = ( result, options = {} ) => {
+    /**
+     * @type {{ lookup: Promise<{ geopoint: string }> | null}}
+     */
+    let mock = { lookup: null };
+
+    beforeEach( () => {
+        mock.lookup = null;
+
+        spyOn( navigator.geolocation, 'getCurrentPosition' ).and.callFake(
+            /**
+             * @param {window.PositionCallback} successCallback - called on success
+             * @param {window.PositionErrorCallback} [errorCallback] - called on failure
+             */
+            ( successCallback, errorCallback ) => {
+                mock.lookup = new Promise( ( resolve ) => {
+                    if ( result instanceof window.GeolocationPositionError ) {
+                        errorCallback( result );
+                        resolve( { geopoint: '' } );
+                    } else {
+                        const position = {
+                            coords: result,
+                            timestamp: Date.now(),
+                        };
+                        successCallback( position );
+
+                        const {
+                            latitude,
+                            longitude,
+                            altitude,
+                            accuracy,
+                        } = result;
+
+                        const geopoint = `${latitude} ${longitude} ${altitude || '0.0'} ${accuracy || '0.0'}`;
+
+                        resolve( { geopoint } );
+                    }
+
+                } );
+            }
+        );
+    } );
+
+    if ( options.expectLookup ) {
+        afterEach( () => {
+            if ( mock.lookup == null ) {
+                fail( 'Geolocation lookup was not performed' );
+            }
+        } );
+    }
+
+    return mock;
+};

--- a/test/spec/form.spec.js
+++ b/test/spec/form.spec.js
@@ -1119,7 +1119,7 @@ describe( 'required enketo-transformer version', () => {
         const actual = Form.requiredTransformerVersion;
 
         expect( actual ).toBe( expected,
-            `It looks like enketo-transformer has been updated in package.json from ${actual} to ${expected}.  You also need to update the value returned by From.getRequiredTransformerVersion() to the new version number.` );
+            `It looks like enketo-transformer has been updated in package.json from ${actual} to ${expected}.  You also need to update the value returned by From.requiredTransformerVersion to the new version number.` );
     } );
 } );
 

--- a/test/spec/setgeopoint.spec.js
+++ b/test/spec/setgeopoint.spec.js
@@ -1,0 +1,91 @@
+import { createGeolocationLookupError, createTestCoordinates, mockGetCurrentPosition } from '../helpers/geolocation';
+import loadForm from '../helpers/load-form';
+
+/*
+ * These tests are for setgeopoint actions. Even though this functionality is part of calculate.js they are separated since they
+ * different features of XForms.
+ */
+
+describe( 'setgeopoint action', () => {
+    describe( 'first load', () => {
+        const mock = mockGetCurrentPosition( createTestCoordinates( {
+            latitude: 48.66,
+            longitude: -120.5,
+            accuracy: 2500.12,
+            altitude: 123,
+        } ), { expectLookup: true } );
+
+        it( 'works for questions with odk-instance-first-load outside of the XForms body', done => {
+            const form1 = loadForm( 'setgeopoint.xml' );
+            form1.init();
+
+            mock.lookup.then( ( { geopoint } ) => {
+                expect( form1.model.xml.querySelector( 'hidden_first_load' ).textContent ).toEqual( geopoint );
+
+                done();
+            } ).catch( fail );
+        } );
+
+        it( 'works for questions with odk-instance-first-load inside of the XForms body', done => {
+            const form1 = loadForm( 'setgeopoint.xml' );
+            form1.init();
+
+            mock.lookup.then( ( { geopoint } ) => {
+                expect( form1.model.xml.querySelector( 'visible_first_load' ).textContent ).toEqual( geopoint );
+
+                done();
+            } ).catch( fail );
+        } );
+    } );
+
+    describe( 'null `accuracy`', () => {
+        const mock = mockGetCurrentPosition( createTestCoordinates( {
+            latitude: 48.66,
+            longitude: -120.5,
+            altitude: 123,
+        } ), { expectLookup: true } );
+
+        it( 'substitutes a null `accuracy` value with 0.0', done => {
+            const form1 = loadForm( 'setgeopoint.xml' );
+            form1.init();
+
+            mock.lookup.then( ( { geopoint } ) => {
+                expect( form1.model.xml.querySelector( 'visible_first_load' ).textContent ).toEqual( geopoint );
+                expect( geopoint ).toEqual( '48.66 -120.5 123 0.0' );
+            } ).catch( fail ).finally( done );
+        } );
+    } );
+
+    describe( 'null `altitude`', () => {
+        const mock = mockGetCurrentPosition( createTestCoordinates( {
+            latitude: 48.66,
+            longitude: -120.5,
+            accuracy: 2500.12,
+        } ), { expectLookup: true } );
+
+        it( 'substitutes a null `altitude` value with 0.0', done => {
+            const form1 = loadForm( 'setgeopoint.xml' );
+            form1.init();
+
+            mock.lookup.then( ( { geopoint } ) => {
+                expect( form1.model.xml.querySelector( 'visible_first_load' ).textContent ).toEqual( geopoint );
+                expect( geopoint ).toMatch( '48.66 -120.5 0.0 2500.12' );
+            } ).catch( fail ).finally( done );
+        } );
+    } );
+
+    describe( 'lookup failure', () => {
+        const mock = mockGetCurrentPosition( createGeolocationLookupError( 'PERMISSION_DENIED' ), { expectLookup: true } );
+
+        it( 'sets an empty string when lookup fails', done => {
+            const form1 = loadForm( 'setgeopoint.xml' );
+            form1.init();
+
+            mock.lookup.then( ( { geopoint } ) => {
+                expect( form1.model.xml.querySelector( 'visible_first_load' ).textContent ).toEqual( geopoint );
+                expect( geopoint ).toMatch( '' );
+            } ).catch( fail ).finally( done );
+        } );
+    } );
+
+} );

--- a/test/spec/widget.geo.spec.js
+++ b/test/spec/widget.geo.spec.js
@@ -1,4 +1,5 @@
 import Geopicker from '../../src/widget/geo/geopicker';
+import { createTestCoordinates, mockGetCurrentPosition } from '../helpers/geolocation';
 import { runAllCommonWidgetTests } from '../helpers/test-widget';
 
 const FORM =
@@ -19,6 +20,14 @@ describe( 'geoshape widget', () => {
         const control = fragment.querySelector( 'input' );
         geoshapePicker = new Geopicker( control );
     } );
+
+    mockGetCurrentPosition( createTestCoordinates( {
+        latitude: 48.66,
+        longitude: -120.5,
+        accuracy: 2500.12,
+        altitude: 123,
+    } ) );
+
 
     describe( 'KML to Leaflet conversion', () => {
         const kmlCoordinates = '81.601884,44.160723 83.529902,43.665148 82.947737,44.248831 81.509322,44.321015',


### PR DESCRIPTION
This implements part of #579, setting a `geopoint` value based on the user's current location on load.

Notes:

- This currently does not work within a `repeat`, discussion in [these](https://github.com/enketo/enketo-core/issues/579#issuecomment-833133293) [comments](https://github.com/enketo/enketo-core/issues/579#issuecomment-833687549).
- This currently depends on a corresponding branch on my fork of `enketo-transformer` until https://github.com/enketo/enketo-transformer/pull/101 is released.
- I generalized the call to `Geolocation#getCurrentPosition`, but it's worth noting that the two calls which already existed had slightly different behavior. I chose the approach that explicitly handled accuracy over the approach which did not. If those were intentionally different I can make those calculations optional.
- I broke up some methods in `calculate.js` to try to reuse as much code from `setvalue` as possible, but if this isn't preferred I'm open to another approach.
- I have chosen a newer distro version in `.travis.yml` in hopes of being able to use the Geolocation API, as the version of Chrome on the previous test run was 30(!) versions behind.