### PR TITLE
Use new data-form-id attribute for formId

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -158,7 +158,7 @@ Form.prototype = {
      * @type {string}
      */
     get id() {
-        return this.view.html.id;
+        return this.view.html.dataset.formId;
     },
     /**
      * To facilitate forks that support multiple constraints per question

--- a/test/spec/form.spec.js
+++ b/test/spec/form.spec.js
@@ -9,6 +9,15 @@ import dialog from '../../src/js/fake-dialog';
 
 dialog.confirm = () => Promise.resolve( true );
 
+describe( 'Getters ', () => {
+    const form = loadForm( 'thedata.xml' );
+    form.init();
+
+    it( 'id() returns the formID', () => {
+        expect( form.id ).toEqual( 'thedata' );
+    } );
+} );
+
 describe( 'Output functionality ', () => {
     // These tests were orginally meant for modilabs/enketo issue #141. However, they passed when they were
     // failing in the enketo client itself (same form). It appeared the issue was untestable (except manually)


### PR DESCRIPTION
Closes #781

See https://github.com/enketo/enketo-transformer/issues/100