### PR TITLE
fixed: OC: Text Multiline item with long values loads with widget condensed

### DIFF
--- a/src/js/dom-utils.js
+++ b/src/js/dom-utils.js
@@ -328,14 +328,14 @@ const elementDataStore = {
 class MutationsTracker{
 
     constructor( el = document.documentElement ){
-        let mutations = 0;
-        let previousMutations = mutations;
+        let currentMutations = 0;
+        let previousMutations = currentMutations;
         this.classChanges = new WeakMap();
         this.quiet = true;
 
         const mutationObserver = new MutationObserver(  mutations => {
             mutations.forEach(  mutation => {
-                mutations++;
+                currentMutations++;
                 if ( mutation.type === 'attributes' && mutation.attributeName === 'class' ){
                     const trackedClasses = this.classChanges.get( mutation.target ) || [];
                     trackedClasses.forEach( obj => {
@@ -358,13 +358,13 @@ class MutationsTracker{
         } );
 
         const checkInterval = setInterval( () => {
-            if ( previousMutations === mutations ){
+            if ( previousMutations === currentMutations ){
                 this.quiet = true;
                 mutationObserver.disconnect();
                 clearInterval( checkInterval );
             } else {
                 this.quiet = false;
-                previousMutations = mutations;
+                previousMutations = currentMutations;
             }
         }, 100 );
     }

--- a/src/widget/textarea/textarea.js
+++ b/src/widget/textarea/textarea.js
@@ -1,5 +1,7 @@
 import Widget from '../../js/widget';
 import events from '../../js/event';
+import { MutationsTracker } from '../../js/dom-utils';
+
 
 /**
  * Auto-resizes textarea elements.
@@ -23,7 +25,11 @@ class TextareaWidget extends Widget {
                 this._resize( el );
             }
         } );
-        textareas.forEach( this._resize.bind( this ) );
+        // workaround for resize issue on first time load textarea with existing value on enketo-express
+        new MutationsTracker( this.element ).waitForQuietness()
+        .then( () => { 
+            textareas.forEach( this._resize.bind( this ) );
+        } );
         this.element.addEventListener( events.PageFlip().type, event => {
             const els = event.target.querySelectorAll( 'textarea' );
             els.forEach( this._resize.bind( this ) );


### PR DESCRIPTION
[#484](https://github.com/OpenClinica/enketo-express-oc/issues/484)