### PR TITLE
Pause multimedia when switching pages

### DIFF
--- a/src/js/page.js
+++ b/src/js/page.js
@@ -365,17 +365,16 @@ export default {
                 this.current.classList.remove( 'current', 'fade-out' );
                 getAncestors( this.current, '.or-group, .or-group-data, .or-repeat', '.or' )
                     .forEach( el => el.classList.remove( 'contains-current' ) );
+                this._pauseMultimedia( this.current );
                 this._setToCurrent( pageEl );
                 this._focusOnFirstQuestion( pageEl );
                 this._toggleButtons( newIndex );
-                this._pauseMultimedia( pageEl );
                 pageEl.dispatchEvent( events.PageFlip() );
             }
         } else if ( pageEl ) {
             this._setToCurrent( pageEl );
             this._focusOnFirstQuestion( pageEl );
             this._toggleButtons( newIndex );
-            this._pauseMultimedia( pageEl );
             pageEl.dispatchEvent( events.PageFlip() );
             pageEl.setAttribute( 'tabindex', 1 );
         }
@@ -429,12 +428,13 @@ export default {
     },
     /**
      * Pauses video and audio from playing when switching to a page.
+     *
      * @param {Element} pageEl - page element
      */
     _pauseMultimedia( pageEl ) {
         $( pageEl )
-            .find('audio, video')
-            .each((idx, element) => element.pause());
+            .find( 'audio, video' )
+            .each( ( idx, element ) => element.pause() );
     },
     /**
      * Updates Table of Contents

--- a/src/js/page.js
+++ b/src/js/page.js
@@ -368,12 +368,14 @@ export default {
                 this._setToCurrent( pageEl );
                 this._focusOnFirstQuestion( pageEl );
                 this._toggleButtons( newIndex );
+                this._pauseMultimedia( pageEl );
                 pageEl.dispatchEvent( events.PageFlip() );
             }
         } else if ( pageEl ) {
             this._setToCurrent( pageEl );
             this._focusOnFirstQuestion( pageEl );
             this._toggleButtons( newIndex );
+            this._pauseMultimedia( pageEl );
             pageEl.dispatchEvent( events.PageFlip() );
             pageEl.setAttribute( 'tabindex', 1 );
         }
@@ -424,6 +426,15 @@ export default {
         this.$btnNext.add( this.$btnLast ).toggleClass( 'disabled', !next );
         this.$btnPrev.add( this.$btnFirst ).toggleClass( 'disabled', !prev );
         this.$formFooter.toggleClass( 'end', !next );
+    },
+    /**
+     * Pauses video and audio from playing when switching to a page.
+     * @param {Element} pageEl - page element
+     */
+    _pauseMultimedia( pageEl ) {
+        $( pageEl )
+            .find('audio, video')
+            .each((idx, element) => element.pause());
     },
     /**
      * Updates Table of Contents


### PR DESCRIPTION
In this PR:
- Pause multimedia (video and audio) from current page before navigating to next/prev page.

This code is a suggestion to fix [this issue](https://github.com/enketo/enketo-core/issues/816).

If this is okay, please consider backport it to 5.18.X, we noticed Enketo version 6.0.0 has a minimum of Node 14, at Medic we still support projects in Node 8 to 12 and won't be able to upgrade Enketo to 6.0.0 for a while.