### PR TITLE
Fix name collision error in repeat

### DIFF
--- a/src/js/calculate.js
+++ b/src/js/calculate.js
@@ -58,7 +58,8 @@ export default {
                      * and the dependent node is inside the same repeat, we can prevent the expensive index determination
                      */
                     const dataNodeName = ( name.lastIndexOf( '/' ) !== -1 ) ? name.substring( name.lastIndexOf( '/' ) + 1 ) : name;
-                    const dataNode = this.form.model.node( updated.repeatPath, updated.repeatIndex ).getElement().querySelector( dataNodeName );
+                    const childNodeList = this.form.model.node( updated.repeatPath, updated.repeatIndex ).getElement().querySelectorAll( dataNodeName );
+                    const dataNode = Array.from(childNodeList).filter( node => dataNodes.includes( node ) )[0];
                     props.index = dataNodes.indexOf( dataNode );
                     this._updateCalc( control, props, emptyNonRelevant );
                 } else if ( control.type === 'hidden' ) {

--- a/test/forms/calcs_in_repeats.xml
+++ b/test/forms/calcs_in_repeats.xml
@@ -15,7 +15,8 @@
             <num1/>
             <grp>
               <note/>
-              <calc3/>
+              <!-- calculate has the same name ("num1") as the int question above to test for name collisions in repeats: https://github.com/enketo/enketo-core/issues/815 -->
+              <num1/>
             </grp>
           </rep1>
           <note1/>
@@ -29,7 +30,7 @@
       <bind nodeset="/calcs_in_repeats/cond1" type="string"/>
       <bind nodeset="/calcs_in_repeats/rep1/num1" type="int"/>
       <bind nodeset="/calcs_in_repeats/rep1/grp" relevant=" /calcs_in_repeats/rep1/num1 > 5 "/>
-      <bind calculate=" /calcs_in_repeats/rep1/num1  * 20" nodeset="/calcs_in_repeats/rep1/grp/calc3" type="string"/>
+      <bind calculate=" /calcs_in_repeats/rep1/num1  * 20" nodeset="/calcs_in_repeats/rep1/grp/num1" type="string"/>
       <bind nodeset="/calcs_in_repeats/note1" readonly="true()" type="string"/>
       <bind calculate="concat('uuid:', uuid())" nodeset="/calcs_in_repeats/meta/instanceID" readonly="true()" type="string"/>
       <bind calculate="'47eed988240249948e42aadfa6bcdb86'" nodeset="/calcs_in_repeats/formhub/uuid" type="string"/>

--- a/test/spec/form.spec.js
+++ b/test/spec/form.spec.js
@@ -304,8 +304,8 @@ describe( 'calculations', () => {
         form.view.$.find( '.add-repeat-btn' ).click();
         form.view.$.find( '[name="/calcs_in_repeats/rep1/num1"]:eq(0)' ).val( '10' ).trigger( 'change' );
         form.view.$.find( '[name="/calcs_in_repeats/rep1/num1"]:eq(1)' ).val( '20' ).trigger( 'change' );
-        expect( form.model.node( '/calcs_in_repeats/rep1/grp/calc3', 0 ).getVal() ).to.equal( '200' );
-        expect( form.model.node( '/calcs_in_repeats/rep1/grp/calc3', 1 ).getVal() ).to.equal( '400' );
+        expect( form.model.node( '/calcs_in_repeats/rep1/grp/num1', 0 ).getVal() ).to.equal( '200' );
+        expect( form.model.node( '/calcs_in_repeats/rep1/grp/num1', 1 ).getVal() ).to.equal( '400' );
     } );
 
     it( 'are not performed if the calculation is not relevant', () => {
@@ -317,9 +317,9 @@ describe( 'calculations', () => {
         form.view.$.find( '[name="/calcs_in_repeats/rep1/num1"]:eq(1)' ).val( '5' ).trigger( 'change' );
         form.view.$.find( '[name="/calcs_in_repeats/rep1/num1"]:eq(2)' ).val( '40' ).trigger( 'change' );
 
-        expect( form.model.node( '/calcs_in_repeats/rep1/grp/calc3', 0 ).getVal() ).to.equal( '400' );
-        expect( form.model.node( '/calcs_in_repeats/rep1/grp/calc3', 1 ).getVal() ).to.equal( '' );
-        expect( form.model.node( '/calcs_in_repeats/rep1/grp/calc3', 2 ).getVal() ).to.equal( '800' );
+        expect( form.model.node( '/calcs_in_repeats/rep1/grp/num1', 0 ).getVal() ).to.equal( '400' );
+        expect( form.model.node( '/calcs_in_repeats/rep1/grp/num1', 1 ).getVal() ).to.equal( '' );
+        expect( form.model.node( '/calcs_in_repeats/rep1/grp/num1', 2 ).getVal() ).to.equal( '800' );
     } );
 
     it( 'outside a repeat are updated if they are dependent on a repeat node', () => {


### PR DESCRIPTION
## Details

Updates the the processing logic for `calculate` fields inside of repeats so that the index gets properly selected even if there are other questions in the same repeat (but not in the same sub-group) with the same name. More details about the issue and how to recreate it are documented in #815.

The change in logic comes when selecting the child nodes of the repeat entry by the `dataNodeName`. Previously, just the first node that was found with a matching name was used. However, this might not be the actual `calculate` node. So, I have updated the logic to filter all the child nodes found with the `dataNodeName` down to just the one that is also present in the `dataNodes` array (with all the instances of that `calculate` field for the repeat). Once the proper `dataNode` is resolved, the index is calculated correctly and the rest of the processing can proceed without error.

## Tests

I am happy to add a new form/test that is specific to this issue if you would like. However, I was able to get test coverage of this issue from the existing tests simply by updating the name of the `calculate` in the `calcs_in_repeats.xml` form to match the question in the repeat.  When I ran the `form.spec.js` tests with the new calculate name, but without the implementation code changes, all of the tests that use the `calcs_in_repeats.xml` form failed as expected with the following error:

```
	Error: Uncaught FormLogicError: Could not evaluate: /model/instance[1]/calcs_in_repeats/rep1/num1  * 20, message: Failed to execute 'evaluate' on 'XPathEvaluator': parameter 2 is not of type 'Node'. (/tmp/08991e993b53562045b647f27beae811-bundle.js:37302)
	    at Object.add (/home/jlkuester7/git/enketo-core/src/js/repeat.js:326:19 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:38070:15)
	    at HTMLButtonElement.<anonymous> (/home/jlkuester7/git/enketo-core/src/js/repeat.js:99:18 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:37951:14)
	    at HTMLFormElement.dispatch (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:5430:27 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:3344:105)
	    at HTMLFormElement.elemData.handle (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:5234:28 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:3232:118)
	    at Object.trigger (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:8719:12 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:5288:24)
	    at HTMLButtonElement.<anonymous> (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:8797:17 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:5334:29)
	    at Function.each (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:385:19 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:770:30)
	    at jQuery2.fn.init.each (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:207:17 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:658:28)
	    at jQuery2.fn.init.trigger (/home/jlkuester7/git/enketo-core/node_modules/jquery/dist/jquery.js:8796:15 <- /tmp/08991e993b53562045b647f27beae811-bundle.js:5333:25)
```
Once the implementation code changes were applied, the test errors were resolved.

Closes #815