### PR TITLE
Fix/randomize 821

### DIFF
--- a/src/js/nodeset.js
+++ b/src/js/nodeset.js
@@ -47,7 +47,7 @@ Nodeset.prototype.getElements = function() {
 
     // cache evaluation result
     if ( !this._nodes ) {
-        this._nodes = this.model.evaluate( this.selector, 'nodes', null, null, true );
+        this._nodes = this.model.evaluate( this.selector, 'nodes-ordered', null, null, true );
         // noEmpty automatically excludes non-leaf nodes
         if ( this.filter.noEmpty === true ) {
             this._nodes = this._nodes

--- a/test/spec/itemset.spec.js
+++ b/test/spec/itemset.spec.js
@@ -581,4 +581,18 @@ describe( 'Itemset functionality', () => {
 
     } );
 
+    describe( 'forms using randomize() for itemsets', () => {
+        it( 'displays randomized select-minimal options ', () => {
+            const form = loadForm( 'randomize.xml' );
+            form.init();
+
+            const options = [ ...form.view.html.querySelectorAll( 'select > option' ) ]
+                .map( option => option.value )
+                .filter( val => val ); // just in case future lists don't contain an empty option
+
+            // This test has a 1/270 chance of failing, I believe.
+            expect( options ).to.not.eql( [  'banana',  'beans', 'cacao', 'coffee', 'foddergrass', 'foddertree' ] );
+        } );
+    } );
+
 } );


### PR DESCRIPTION
Issue can be reproduced with http://localhost:8005/?xform=randomize.xml in master.

It is quite serious and it is surprising only one person has reported it so far. 

The fix is to used unordered snapshot results when evaluating user-defined XPath expressions. Out of an abundance of caution I kept some internal node-set XPath queries as ordered (though none of the tests failed).

It is possible that there is some use case (querying a secondary instance e.g.) that causes a problem, but I think it's quite unlikely, and considering the seriousness of this bug, I propose to go ahead with this fix unless a real issue can be identified of course.