### PR TITLE
Fix: Firefox DatetimepickerExtended tests

### DIFF
--- a/src/widget/datetime/datetimepicker-extended.js
+++ b/src/widget/datetime/datetimepicker-extended.js
@@ -144,6 +144,20 @@ class DatetimepickerExtended extends Widget {
         }
     }
 
+    get originalInputValue() {
+        const originalInputValue = super.originalInputValue;
+
+        if ( originalInputValue === '' ) {
+            return '';
+        }
+
+        return toISOLocalString( new Date( originalInputValue ) );
+    }
+
+    set originalInputValue( value ) {
+        super.originalInputValue = value;
+    }
+
     /**
      * @type {string}
      */

--- a/test/spec/widget.datetime.spec.js
+++ b/test/spec/widget.datetime.spec.js
@@ -46,7 +46,7 @@ describe( 'datetimepicker widget', () => {
             fakeDateInput.dispatchEvent( new Event( 'change' ) );
 
             // timezone info will be added by engine
-            expect( input.value ).to.equal( '2012-01-01T01:01:00.000' );
+            expect( input.value.endsWith( '-07:00' ) ).to.equal( false );
             expect( input.onchange.callCount ).to.equal( 1 );
 
             // reset value in fake input manually


### PR DESCRIPTION
- Ensures `originalInputValue` output consistently outputs seconds and milliseconds
- Relaxes test for the value of the widget's backing `datetime-local` input