### PR TITLE
Add forgotten updates, release checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ---------------------
 
 ##### Changed
-
+- Improve build speed (#838)
+- Fix deprecatedID not added and populated properly if meta block is name-spaced with http://openrosa.org/xforms (#836)
 - Fix outputs in labels of radiobutton/checkbox itemsets within grouped repeats (#846)
+- Pause multimedia when switching pages (#817)
 - Upgraded to [openrosa-xpath-evaluator 2.0.10](https://github.com/enketo/openrosa-xpath-evaluator/blob/master/CHANGELOG.md#2010---2022-02-01)
 - Upgraded to [enketo-transformer 2.1.2](https://github.com/enketo/enketo-transformer/blob/master/CHANGELOG.md#212---2022-02-01)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ We have to admit we do not test on all of these, but are committed to fixing bro
 
 [Here is some guidance](https://enketo.github.io/enketo-core/tutorial-90-ie11.html) that may be helpful when trying to create a build that possibly runs on Internet Explorer 11.
 
+### Releases
+1. Create release PR
+1. Check [Dependabot](https://github.com/enketo/enketo-transformer/security/dependabot) for alerts
+1. Run `npm update`
+    -  Check if `node-forge` has been updated and if so, verify encrypted submissions end-to-end
+1. Run `npm audit`
+    - Run `npm audit fix --production` to apply most important fixes
+1. Run `npm ci`
+1. Run `npm test`
+1. Run `npm run build-docs`
+1. Update `CHANGELOG.md`
+1. Update version in `package.json`
+    - Bump to major version if consumers have to make changes.
+1. Merge PR with all changes
+1. Create GitHub release
+1. Tag and publish the release
+    - GitHub Action will publish it to npm
+
 ### Sponsors
 
 The development of this library was sponsored by:


### PR DESCRIPTION
I missed that https://github.com/enketo/enketo-core/pull/860 forgot some updates.

Also adds a release checklist to reduce likelihood of omissions.