### PR TITLE
Prepare for 6.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+[6.0.4] - 2022-02-04
+---------------------
+
+##### Changed
+
+- Fix: Disable <option>s for readonly <select>s with itemsets (#843)
+
 [6.0.3] - 2022-02-03
 ---------------------
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We have to admit we do not test on all of these, but are committed to fixing bro
 
 ### Releases
 1. Create release PR
-1. Check [Dependabot](https://github.com/enketo/enketo-transformer/security/dependabot) for alerts
+1. Check [Dependabot](https://github.com/enketo/enketo-core/security/dependabot) for alerts
 1. Run `npm update`
     -  Check if `node-forge` has been updated and if so, verify encrypted submissions end-to-end
 1. Run `npm audit`

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,6 +81,37 @@
 </ul>
 <p>We have to admit we do not test on all of these, but are committed to fixing browser-specific bugs that are reported for these browsers. Naturally, older browsers versions will often work as well - they are just not officially supported.</p>
 <p><a href="https://enketo.github.io/enketo-core/tutorial-90-ie11.html">Here is some guidance</a> that may be helpful when trying to create a build that possibly runs on Internet Explorer 11.</p>
+<h3 id="releases">Releases</h3>
+<ol>
+<li>Create release PR</li>
+<li>Check <a href="https://github.com/enketo/enketo-transformer/security/dependabot">Dependabot</a> for alerts</li>
+<li>Run <code>npm update</code>
+<ul>
+<li>Check if <code>node-forge</code> has been updated and if so, verify encrypted submissions end-to-end</li>
+</ul>
+</li>
+<li>Run <code>npm audit</code>
+<ul>
+<li>Run <code>npm audit fix --production</code> to apply most important fixes</li>
+</ul>
+</li>
+<li>Run <code>npm ci</code></li>
+<li>Run <code>npm test</code></li>
+<li>Run <code>npm run build-docs</code></li>
+<li>Update <code>CHANGELOG.md</code></li>
+<li>Update version in <code>package.json</code>
+<ul>
+<li>Bump to major version if consumers have to make changes.</li>
+</ul>
+</li>
+<li>Merge PR with all changes</li>
+<li>Create GitHub release</li>
+<li>Tag and publish the release
+<ul>
+<li>GitHub Action will publish it to npm</li>
+</ul>
+</li>
+</ol>
 <h3 id="sponsors">Sponsors</h3>
 <p>The development of this library was sponsored by:</p>
 <ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
 <h3 id="releases">Releases</h3>
 <ol>
 <li>Create release PR</li>
-<li>Check <a href="https://github.com/enketo/enketo-transformer/security/dependabot">Dependabot</a> for alerts</li>
+<li>Check <a href="https://github.com/enketo/enketo-core/security/dependabot">Dependabot</a> for alerts</li>
 <li>Run <code>npm update</code>
 <ul>
 <li>Check if <code>node-forge</code> has been updated and if so, verify encrypted submissions end-to-end</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-core",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -695,9 +695,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "17.0.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.13.tgz",
-            "integrity": "sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==",
+            "version": "17.0.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
+            "integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -1570,9 +1570,9 @@
             }
         },
         "cookie": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
             "dev": true
         },
         "cookie-signature": {
@@ -4543,9 +4543,9 @@
             "dev": true
         },
         "karma": {
-            "version": "6.3.12",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.12.tgz",
-            "integrity": "sha512-qwIG+oB2YmHx4hjvYSRMNzL3YWAJ9baHaLAxiP7biFNkfpwYTUTtPck0joFpucalNLzMr+7z/FX1uY/kl8DV9A==",
+            "version": "6.3.14",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.14.tgz",
+            "integrity": "sha512-SDFoU5F4LdosEiUVWUDRPCV/C1zQRNtIakx7rWkigf7R4sxGADlSEeOma4S1f/js7YAzvqLW92ByoiQptg+8oQ==",
             "dev": true,
             "requires": {
                 "body-parser": "^1.19.0",
@@ -4560,7 +4560,7 @@
                 "http-proxy": "^1.18.1",
                 "isbinaryfile": "^4.0.8",
                 "lodash": "^4.17.21",
-                "log4js": "^6.3.0",
+                "log4js": "^6.4.1",
                 "mime": "^2.5.2",
                 "minimatch": "^3.0.4",
                 "qjobs": "^1.2.0",
@@ -4578,20 +4578,6 @@
                     "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
                     "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
                     "dev": true
-                },
-                "glob": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-                    "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
                 },
                 "mime": {
                     "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-core",
     "description": "Extensible Enketo form engine",
     "homepage": "https://enketo.org",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "license": "Apache-2.0",
     "os": [
         "darwin",
@@ -72,7 +72,7 @@
         "istanbul-reporter-shield-badge": "^1.2.1",
         "jsdoc": "^3.6.10",
         "json-pretty": "0.0.1",
-        "karma": "^6.3.12",
+        "karma": "^6.3.14",
         "karma-chrome-launcher": "^3.1.0",
         "karma-coverage": "^2.1.0",
         "karma-esbuild": "^2.2.0",


### PR DESCRIPTION
**Note:** I think we can safely remove `node-forge` from enketo-core, which doesn't directly use it anywhere I can find. Unless there's some dynamic usage I'm not aware of which wouldn't be provided by dependent projects, I'd prefer to remove it both as a dependency and as a step in the release process.

- [x] Create release PR
- [x] Check [Dependabot](https://github.com/enketo/enketo-transformer/security/dependabot) for alerts
- [x] Run `npm update`
    - [x] Check if `node-forge` has been updated and if so, verify encrypted submissions end-to-end
- [x] Run `npm audit`
    - Run `npm audit fix --production` to apply most important fixes
- [x] Run `npm ci`
- [x] Run `npm test`
- [x] Run `npm run build-docs`
- [x] Update `CHANGELOG.md`
- [x] Update version in `package.json`
    - N/A: Bump to major version if consumers have to make changes.
- [ ] Merge PR with all changes @lognaturel
- [ ] Create GitHub release @lognaturel
- [ ] Tag and publish the release @lognaturel
    - GitHub Action will publish it to npm