### PR TITLE
Update `datepicker-extended` widget to properly unpack data from paste event

### DIFF
--- a/src/widget/date/datepicker-extended.js
+++ b/src/widget/date/datepicker-extended.js
@@ -90,7 +90,9 @@ class DatepickerExtended extends Widget {
         $fakeDateI.on('change paste', (e) => {
             let convertedValue = '';
             let value =
-                e.type === 'paste' ? getPasteData(e.originalEvent ?? e) : this.value;
+                e.type === 'paste'
+                    ? getPasteData(e.originalEvent ?? e)
+                    : this.value;
 
             if (value.length > 0) {
                 // Note: types.date.convert considers numbers to be a number of days since the epoch

--- a/src/widget/date/datepicker-extended.js
+++ b/src/widget/date/datepicker-extended.js
@@ -89,7 +89,7 @@ class DatepickerExtended extends Widget {
 
         $fakeDateI.on('change paste', (e) => {
             let convertedValue = '';
-            let value = e.type === 'paste' ? getPasteData(e) : this.value;
+            let value = e.type === 'paste' ? getPasteData(e.originalEvent) : this.value;
 
             if (value.length > 0) {
                 // Note: types.date.convert considers numbers to be a number of days since the epoch

--- a/src/widget/date/datepicker-extended.js
+++ b/src/widget/date/datepicker-extended.js
@@ -89,7 +89,8 @@ class DatepickerExtended extends Widget {
 
         $fakeDateI.on('change paste', (e) => {
             let convertedValue = '';
-            let value = e.type === 'paste' ? getPasteData(e.originalEvent) : this.value;
+            let value =
+                e.type === 'paste' ? getPasteData(e.originalEvent) : this.value;
 
             if (value.length > 0) {
                 // Note: types.date.convert considers numbers to be a number of days since the epoch

--- a/src/widget/date/datepicker-extended.js
+++ b/src/widget/date/datepicker-extended.js
@@ -90,7 +90,7 @@ class DatepickerExtended extends Widget {
         $fakeDateI.on('change paste', (e) => {
             let convertedValue = '';
             let value =
-                e.type === 'paste' ? getPasteData(e.originalEvent) : this.value;
+                e.type === 'paste' ? getPasteData(e.originalEvent ?? e) : this.value;
 
             if (value.length > 0) {
                 // Note: types.date.convert considers numbers to be a number of days since the epoch

--- a/test/spec/widget.date.spec.js
+++ b/test/spec/widget.date.spec.js
@@ -63,8 +63,10 @@ describe('datepicker widget', () => {
 
             it(`sets date value when pasting ${desc} fields`, () => {
                 const clipboardData = new DataTransfer();
-                clipboardData.setData('text/plain', newVal)
-                fakeInput.dispatchEvent(new ClipboardEvent('paste', { clipboardData }));
+                clipboardData.setData('text/plain', newVal);
+                fakeInput.dispatchEvent(
+                    new ClipboardEvent('paste', { clipboardData })
+                );
 
                 expect(input.value).to.equal('2012-01-01');
             });
@@ -72,7 +74,7 @@ describe('datepicker widget', () => {
 
         [
             ['full date', FORM1],
-            ['month-year', FORM2]
+            ['month-year', FORM2],
         ].forEach(([desc, form]) => {
             it(`sets empty string when pasting year and appearance is ${desc}`, () => {
                 const input = initForm(form).element;
@@ -81,8 +83,10 @@ describe('datepicker widget', () => {
                     .querySelector('.widget input');
 
                 const clipboardData = new DataTransfer();
-                clipboardData.setData('text/plain', '2012')
-                fakeInput.dispatchEvent(new ClipboardEvent('paste', { clipboardData }));
+                clipboardData.setData('text/plain', '2012');
+                fakeInput.dispatchEvent(
+                    new ClipboardEvent('paste', { clipboardData })
+                );
 
                 expect(input.value).to.equal('');
             });

--- a/test/spec/widget.date.spec.js
+++ b/test/spec/widget.date.spec.js
@@ -62,11 +62,12 @@ describe('datepicker widget', () => {
             });
 
             it(`sets date value when pasting ${desc} fields`, () => {
-                const clipboardData = new DataTransfer();
-                clipboardData.setData('text/plain', newVal);
-                fakeInput.dispatchEvent(
-                    new ClipboardEvent('paste', { clipboardData })
-                );
+                const event = new ClipboardEvent('paste', {
+                    clipboardData: new DataTransfer(),
+                });
+                event.clipboardData.setData('text/plain', newVal);
+
+                fakeInput.dispatchEvent(event);
 
                 expect(input.value).to.equal('2012-01-01');
             });
@@ -81,12 +82,12 @@ describe('datepicker widget', () => {
                 const fakeInput = input
                     .closest('.question')
                     .querySelector('.widget input');
+                const event = new ClipboardEvent('paste', {
+                    clipboardData: new DataTransfer(),
+                });
+                event.clipboardData.setData('text/plain', '2012');
 
-                const clipboardData = new DataTransfer();
-                clipboardData.setData('text/plain', '2012');
-                fakeInput.dispatchEvent(
-                    new ClipboardEvent('paste', { clipboardData })
-                );
+                fakeInput.dispatchEvent(event);
 
                 expect(input.value).to.equal('');
             });

--- a/test/spec/widget.date.spec.js
+++ b/test/spec/widget.date.spec.js
@@ -60,6 +60,32 @@ describe('datepicker widget', () => {
 
                 expect(input.value).to.equal('');
             });
+
+            it(`sets date value when pasting ${desc} fields`, () => {
+                const clipboardData = new DataTransfer();
+                clipboardData.setData('text/plain', newVal)
+                fakeInput.dispatchEvent(new ClipboardEvent('paste', { clipboardData }));
+
+                expect(input.value).to.equal('2012-01-01');
+            });
+        });
+
+        [
+            ['full date', FORM1],
+            ['month-year', FORM2]
+        ].forEach(([desc, form]) => {
+            it(`sets empty string when pasting year and appearance is ${desc}`, () => {
+                const input = initForm(form).element;
+                const fakeInput = input
+                    .closest('.question')
+                    .querySelector('.widget input');
+
+                const clipboardData = new DataTransfer();
+                clipboardData.setData('text/plain', '2012')
+                fakeInput.dispatchEvent(new ClipboardEvent('paste', { clipboardData }));
+
+                expect(input.value).to.equal('');
+            });
         });
     });
 });


### PR DESCRIPTION
When pasting values into the `datepicker-extended` widget, the following error is printed to the browser console:

```
Uncaught TypeError: Cannot read properties of null (reading 'length')
```

This is because the widget code is not getting the `originalEvent` from the jQuery event wrapper before unpacking the paste data.

(It is worth noting that the only other place the `getPasteData` util function is being used, in [`mask.js`](https://github.com/enketo/enketo-core/blob/51c5c2f494f1515a67355543b435f6aaa4b151b4/src/js/mask.js#L54), appears to work fine since it is passing the normal browser event (and not the jQuery event)).

Closes #877 