### PR TITLE
Optionally recompute the evaluation cascade asynchronously

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,18 @@
-export default {
+export default /** @type {const} */ ({
+    experimentalOptimizations: {
+        /**
+         * When set to `true`, recomputations of the evaluation cascade will be performed
+         * asynchronously to reduce time spent blocking UI updates. This may be improve
+         * perceived performance on large forms with complex chained computations. These
+         * computations are technically delayed and will perform more slowly, but their
+         * corresponding UI updates will render more quickly as each step in the chain of
+         * computations completes.
+         */
+        computeAsync: window.location.search.includes('&computeAsync'),
+    },
+
+    forceClearNonRelevant: window.location.search.includes('&clearNonRelevant'),
+
     maps: [
         {
             tiles: ['https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'],
@@ -17,4 +31,4 @@ export default {
     validatePage: true,
     swipePage: true,
     textMaxChars: 2000,
-};
+});

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -98,19 +98,25 @@ Form.prototype = {
             this.validationUpdate,
         ];
 
-        let evaluationCascade;
+        const { evaluationCascadeAdditions } = this;
+
+        if (evaluationCascadeAdditions.length > 0) {
+            baseEvaluationCascade.push(() => {
+                for (const fn of evaluationCascadeAdditions) {
+                    fn();
+                }
+            });
+        }
 
         if (config.experimentalOptimizations.computeAsync) {
-            evaluationCascade = baseEvaluationCascade.map(
+            return baseEvaluationCascade.map(
                 (fn) =>
                     (...args) =>
                         callOnIdle(() => fn(...args))
             );
-        } else {
-            evaluationCascade = baseEvaluationCascade;
         }
 
-        return evaluationCascade.concat(this.evaluationCascadeAdditions);
+        return baseEvaluationCascade;
     },
     /**
      * @type {string}

--- a/src/js/relevant.js
+++ b/src/js/relevant.js
@@ -4,6 +4,7 @@
  * @description Updates branches
  */
 
+import config from 'enketo/config';
 import events from './event';
 import { closestAncestorUntil, getChild, getChildren } from './dom-utils';
 
@@ -12,7 +13,7 @@ export default {
      * @param {UpdatedDataNodes} [updated] - The object containing info on updated data nodes.
      * @param {boolean} forceClearNonRelevant -  whether to empty the values of non-relevant nodes
      */
-    update(updated, forceClearNonRelevant = false) {
+    update(updated, forceClearNonRelevant = config.forceClearNonRelevant) {
         if (!this.form) {
             throw new Error(
                 'Branch module not correctly instantiated with form property.'
@@ -29,7 +30,7 @@ export default {
      * @param {Array<Element>} nodes - Nodes to update
      * @param {boolean} forceClearNonRelevant - whether to empty the values of non-relevant nodes
      */
-    updateNodes(nodes, forceClearNonRelevant = false) {
+    updateNodes(nodes, forceClearNonRelevant = config.forceClearNonRelevant) {
         let branchChange = false;
         const relevantCache = {};
         const alreadyCovered = [];
@@ -200,7 +201,12 @@ export default {
      * @param {boolean} result - result of relevant evaluation
      * @param {boolean} forceClearNonRelevant - whether to empty the values of non-relevant nodes
      */
-    process(branchNode, path, result, forceClearNonRelevant = false) {
+    process(
+        branchNode,
+        path,
+        result,
+        forceClearNonRelevant = config.forceClearNonRelevant
+    ) {
         if (result === true) {
             return this.enable(branchNode, path);
         }

--- a/src/js/timers.js
+++ b/src/js/timers.js
@@ -1,0 +1,24 @@
+/** @type {(callback: () => void, maxDelay: number) => void} */
+const onIdle =
+    typeof requestIdleCallback === 'function'
+        ? (callback, timeout) => {
+              requestIdleCallback(callback, { timeout });
+          }
+        : (callback) => {
+              setTimeout(callback);
+          };
+
+/**
+ * Queues `callback` to be called asynchronously:
+ *
+ * - using `requestIdleCallback` where supported, on idle or after `maxDelay` milliseconds
+ *   (default: `10`), whichever comes first
+ * - falling back to `setTimeout` with the minimum delay (varies by browser, but generally
+ *   4 milliseconds
+ *
+ * @param {() => void} callback
+ * @param {number} maxDelay
+ */
+export const callOnIdle = (callback, maxDelay = 16) => {
+    onIdle(callback, maxDelay);
+};

--- a/src/js/timers.js
+++ b/src/js/timers.js
@@ -1,4 +1,11 @@
-/** @type {(callback: () => void, maxDelay: number) => void} */
+/**
+ * @callback OnIdle
+ * @param {Function} callback
+ * @param {number} maxDelay
+ * @return {void}
+ */
+
+/** @type {OnIdle} */
 const onIdle =
     typeof requestIdleCallback === 'function'
         ? (callback, timeout) => {
@@ -16,7 +23,7 @@ const onIdle =
  * - falling back to `setTimeout` with the minimum delay (varies by browser, but generally
  *   4 milliseconds
  *
- * @param {() => void} callback
+ * @param {Function} callback
  * @param {number} maxDelay
  */
 export const callOnIdle = (callback, maxDelay = 16) => {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -11,6 +11,12 @@ module.exports = (config) => {
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks: ['mocha', 'sinon-chai'],
 
+        client: {
+            mocha: {
+                timeout: 10000,
+            },
+        },
+
         // list of files / patterns to load in the browser
         files: [
             'test/mock/*.js',

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
         // list of files / patterns to load in the browser
         files: [
             'test/mock/*.js',
-            'test/spec/*.spec.js',
+            'test/spec/**/*.spec.js',
             {
                 pattern: 'src/js/*.js',
                 included: false,
@@ -38,6 +38,12 @@ module.exports = (config) => {
             'config.js': ['esbuild'],
             'src/**/*.js': ['esbuild'],
             'test/**/*.js': ['esbuild'],
+        },
+
+        esbuild: {
+            define: {
+                ENV: '"test"',
+            },
         },
 
         browserify: {

--- a/test/spec/performance/evaluation-cascade.spec.js
+++ b/test/spec/performance/evaluation-cascade.spec.js
@@ -1,0 +1,222 @@
+import loadForm from '../../helpers/load-form';
+import config from '../../../config';
+import dialog from '../../../src/js/fake-dialog';
+import events from '../../../src/js/event';
+
+describe('Evaluation Cascade', () => {
+    /** @type {import('sinon').SinonSandbox} */
+    let sandbox;
+
+    /** @type {boolean} */
+    let forceClearNonRelevant;
+
+    /** @type {boolean} */
+    let computeAsync;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        sandbox.stub(dialog, 'confirm').resolves(true);
+
+        forceClearNonRelevant = false;
+
+        sandbox
+            .stub(config, 'forceClearNonRelevant')
+            .get(() => forceClearNonRelevant);
+
+        computeAsync = false;
+
+        sandbox
+            .stub(config.experimentalOptimizations, 'computeAsync')
+            .get(() => computeAsync);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('Computing relevance changes asynchronously', () => {
+        /** @type {SinonFakeTimers} */
+        let timers;
+
+        beforeEach(() => {
+            computeAsync = true;
+            forceClearNonRelevant = true;
+
+            timers = sandbox.useFakeTimers();
+        });
+
+        afterEach(() => {
+            timers.runAll();
+
+            timers.clearTimeout();
+            timers.clearInterval();
+            timers.restore();
+            sandbox.restore();
+        });
+
+        it('clears non-relevant values asynchronously', () => {
+            const form = loadForm('va_who_v1_5_3.xml');
+
+            form.init();
+            timers.runAll();
+
+            const didConsent = form.view.html.querySelector(
+                '[name="/data/respondent_backgr/Id10013"][value="yes"]'
+            );
+
+            const consentedGroup = form.view.html.querySelector(
+                '.or-group[name="/data/consented"]'
+            );
+
+            // Per `Form#grosslyViolateStandardComplianceByIgnoringCertainCalcs`, calculations
+            // are removed from preload nodes.
+            const consentedQuestions = consentedGroup.querySelectorAll(
+                '.question input:not(.ignore, [data-preload])'
+            );
+
+            for (const node of consentedQuestions) {
+                if (node.type === 'checkbox' || node.type === 'radio') {
+                    expect(node.checked).to.equal(false);
+                } else {
+                    expect(node.value).to.equal('');
+                }
+            }
+
+            didConsent.checked = true;
+            didConsent.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const isDateOfBirthKnown = form.view.html.querySelector(
+                '[name="/data/consented/deceased_CRVS/info_on_deceased/Id10020"][value="yes"]'
+            );
+
+            isDateOfBirthKnown.checked = true;
+            isDateOfBirthKnown.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const dateOfBirth = form.view.html.querySelector(
+                '[name="/data/consented/deceased_CRVS/info_on_deceased/Id10021"]'
+            );
+
+            const adultDateOfBirth = new Date();
+
+            adultDateOfBirth.setFullYear(adultDateOfBirth.getFullYear() - 18);
+
+            const adultDateOfBirthValue = adultDateOfBirth
+                .toISOString()
+                .replace(/T.*$/, '');
+
+            dateOfBirth.value = adultDateOfBirthValue;
+            dateOfBirth.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const isDateOfDeathKnown = form.view.html.querySelector(
+                '[name="/data/consented/deceased_CRVS/info_on_deceased/Id10022"][value="no"]'
+            );
+
+            isDateOfDeathKnown.checked = true;
+            isDateOfDeathKnown.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const yearOfDeath = form.view.html.querySelector(
+                '[name="/data/consented/deceased_CRVS/info_on_deceased/Id10024"]'
+            );
+            const yearOfDeathValue = new Date()
+                .toISOString()
+                .replace(/T.*$/, '');
+
+            yearOfDeath.value = yearOfDeathValue;
+            yearOfDeath.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const ageGroup = form.view.html.querySelector(
+                '[name="/data/consented/deceased_CRVS/info_on_deceased/age_group"][value="adult"]'
+            );
+
+            ageGroup.checked = true;
+            ageGroup.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const didHaveFever = form.view.html.querySelector(
+                '[name="/data/consented/illhistory/signs_symptoms_final_illness/Id10147"][value="yes"]'
+            );
+
+            didHaveFever.checked = true;
+            didHaveFever.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const feverDurationDayUnit = form.view.html.querySelector(
+                '[name="/data/consented/illhistory/signs_symptoms_final_illness/Id10148_units"][value="days"]'
+            );
+
+            feverDurationDayUnit.checked = true;
+            feverDurationDayUnit.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const feverDurationDays = form.view.html.querySelector(
+                '[name="/data/consented/illhistory/signs_symptoms_final_illness/Id10148_b"]'
+            );
+
+            feverDurationDays.value = '36';
+            feverDurationDays.dispatchEvent(events.Change());
+
+            timers.runAll();
+
+            const isDateOfBirthKnownModelNode = form.model
+                .node(isDateOfBirthKnown.name)
+                .getElement();
+            const dateOfBirthModelNode = form.model
+                .node(dateOfBirth.name)
+                .getElement();
+            const isDateOfDeathKnownModelNode = form.model
+                .node(isDateOfDeathKnown.name)
+                .getElement();
+            const yearOfDeathModelNode = form.model
+                .node(yearOfDeath.name)
+                .getElement();
+            const ageGroupModelNode = form.model
+                .node(ageGroup.name)
+                .getElement();
+            const didHaveFeverModelNode = form.model
+                .node(didHaveFever.name)
+                .getElement();
+            const feverDurationDayUnitModelNode = form.model
+                .node(feverDurationDayUnit.name)
+                .getElement();
+            const feverDurationDaysModelNode = form.model
+                .node(feverDurationDays.name)
+                .getElement();
+
+            expect(isDateOfBirthKnownModelNode.textContent).to.equal('yes');
+            expect(dateOfBirthModelNode.textContent).to.equal(
+                adultDateOfBirthValue
+            );
+            expect(isDateOfDeathKnownModelNode.textContent).to.equal('no');
+            expect(yearOfDeathModelNode.textContent).to.equal(yearOfDeathValue);
+            expect(ageGroupModelNode.textContent).to.equal('adult');
+            expect(didHaveFeverModelNode.textContent).to.equal('yes');
+            expect(feverDurationDayUnitModelNode.textContent).to.equal('days');
+            expect(feverDurationDaysModelNode.textContent).to.equal('36');
+
+            didHaveFever.checked = false;
+            didHaveFever.dispatchEvent(events.Change());
+
+            expect(feverDurationDayUnitModelNode.textContent).to.equal('days');
+            expect(feverDurationDaysModelNode.textContent).to.equal('36');
+
+            timers.runAll();
+
+            expect(feverDurationDayUnitModelNode.textContent).to.equal('');
+            expect(feverDurationDaysModelNode.textContent).to.equal('');
+        }, 1000000);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,10 @@
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "strict": true,
-        "target": "es2018"
+        "target": "es2018",
+        "paths": {
+            "enketo/config": ["./config.js"]
+        }
     },
     "exclude": ["node_modules"],
     "include": ["src", "test", "typings"]


### PR DESCRIPTION
### Async evaluation cascade

Currently under the feature flag `config.experimentalOptimizations.computeAsync`, this allows the evaluation cascade to be performed asynchronously. This improves UI responsiveness for expensive calculations, especially when chained. Currently the feature flag can be enabled dynamically by appending `&computeAsync` to the URL when running the validation app.

This is achieved using [`requestIdleCallback`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback)[^1], which calls the callback on when the event loop is idle or after `timeout` milliseconds, whichever comes first. The default `timeout` of `16` is approximately the number of milliseconds which would achieve 60 frames per second. This was chosen over `requestAnimationFrame` because the latter is higher priority, calling the callback _before_ the next tick of the event loop.

[^1]: Where available. In browsers which don't currently support `requestIdleCallback` (currently Safari, unless enabled with a flag), it will fall back to `setTimeout` with no delay.

### Risks of async

While I don't believe this specific change introduces a possibility of a race condition, it's _possible_ I have missed a case where it would. As MDN notes:

> Functions are generally called in first-in-first-out order; however, callbacks which have a `timeout` specified may be called out-of-order if necessary in order to run them before the timeout elapses.

In my experience, this has not been the case. I expect that's because callbacks requested with the `timeout` value are effectively placed in a priority queue. When `timeout` is always the same value, the priority should always be the same. But there's a possibility I've misunderstood this and the evaluation cascade order may be unstable with this setting.

My goal in calling this out is:

- To have my understanding of this risk validated/scrutinized in review
- If we determine the risk is as low as I believe, consider whether to remove the feature flag and make this the default behavior
- Otherwise, consider ways we can have users test/validate the behavior

### Validation of perceived performance with async

This change also (likely temporarily, pending #870) reintroduces an option `config.forceClearNonRelevant` to clear non-relevant values. This flag can also be enabled by appending `&clearNonRelevant` to the validation app URL. This differs from #870 in that it will not restore values which have been cleared on questions which become relevant again. This setting was introduced to simulate similar performance issues found in #870 on the large WHO form (also included in this PR).

The perceived performance difference can be observed by comparing:

1. Open the large WHO form
2. Click Go to End
3. Answer "Yes" to "Did the respondent give consent?"
4. Switch the answer to "No"

What you should see:

- With both flags off, there's a brief delay on step 3 before the "Yes" radio appears checked. Step 4, and any repetition of steps 3-4 should feel instantaneous.
- With only `&clearNonRelevant`, both steps 3 and 4 have a noticeably longer delay, even when repeated.
- With both flags enabled, steps 3 and 4 should feel instantaneous or nearly so each time.

### Other changes and details

In the course of validating these changes against a few other forms [found here](https://forum.getodk.org/t/share-your-biggest-or-slowest-form-and-win-a-badge/8984), I noticed that the SOAR form also included in this PR was quite slow to load.

Initially I considered applying the same async approach to `Form#init`, but backed out of this because:

- It would change the method's signature. Although this could be isolated with the feature flag, that would not be possible should this ever become the default approach.
- I couldn't find an effective way, with the SOAR form, to improve _perceived_ initial load time (roughly analogous to [First Contentful Paint](https://developer.mozilla.org/en-US/docs/Glossary/First_contentful_paint)) without introducing quite a lot of delayed repaints. This felt like a worse user experience than simply accepting the full loading time delay.

That said, I discovered on that form that the largest performance impact on load was recalculating for each repeat as its template was added to the form. I was able to improve the _actual_ load time significantly (from about 8-10 seconds on my computer to about 2-3 seconds) by performing all of those calculations at once after all repeats are added.

### Risks of init repeat calculation changes

I refined this portion of the change several times, with each earlier approach failing certain tests. My hope is that with those tests failing, then passing, there is enough coverage that any other behavior change I might have missed would be caught. But my confidence in that is slightly lower than my confidence in the safety of the async change, so I feel it's important to call that out. Repeat behavior is tested _extensively_, of course, with many edge cases considered. But I'm hoping review will validate that this change is desired and safe.

I didn't place this change behind a feature flag, mainly because I forgot to do that in haste of opening this PR. I'd be happy to make that change if desired.