### PR TITLE
Improve test isolation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -119,7 +119,9 @@
                 "sinon": true
             },
             "rules": {
-                "no-console": "off"
+                "no-console": "off",
+                "no-unused-expressions": "off",
+                "chai-friendly/no-unused-expressions": "warn"
             }
         }
     ]

--- a/test/spec/format.spec.js
+++ b/test/spec/format.spec.js
@@ -18,7 +18,6 @@ describe('Format', () => {
     });
 
     describe('for time determination', () => {
-        let i;
         const t = [
             ['en-US', true, 'AM', 'PM'],
 
@@ -44,7 +43,7 @@ describe('Format', () => {
             });
         }
 
-        for (i = 0; i < t.length; i++) {
+        for (let i = 0; i < t.length; i += 1) {
             testMeridian(t[i][0], t[i][1]);
         }
 
@@ -56,7 +55,7 @@ describe('Format', () => {
             });
         }
 
-        for (i = 0; i < t.length; i++) {
+        for (let i = 0; i < t.length; i += 1) {
             testPm(t[i][0], t[i][2], t[i][3]);
         }
     });

--- a/test/spec/page.spec.js
+++ b/test/spec/page.spec.js
@@ -2,19 +2,39 @@ import loadForm from '../helpers/load-form';
 
 describe('Pages mode', () => {
     describe('Initial loading if form includes repeats-as-page', () => {
-        it('loads to the proper first page', (done) => {
+        /** @type {import('sinon').SinonSandbox} */
+        let sandbox;
+
+        /** @type {SinonFakeTimers} */
+        let timers;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            timers = sandbox.useFakeTimers();
+        });
+
+        afterEach(() => {
+            timers.runAll();
+
+            timers.clearTimeout();
+            timers.clearInterval();
+            timers.restore();
+            sandbox.restore();
+        });
+
+        it('loads to the proper first page', () => {
             const form = loadForm('pages.xml');
             form.init();
 
             // something asynchronous happening, validation probably
-            setTimeout(() => {
-                const firstQuestion = form.view.html.querySelector('.question');
-                const currentInModule = form.pages.current;
-                const currentInView = form.view.html.querySelector('.current');
-                expect(currentInModule).to.equal(firstQuestion);
-                expect(currentInView).to.equal(firstQuestion);
-                done();
-            }, 500);
+            const firstQuestion = form.view.html.querySelector('.question');
+            const currentInModule = form.pages.current;
+            const currentInView = form.view.html.querySelector('.current');
+
+            timers.runAll();
+
+            expect(currentInModule).to.equal(firstQuestion);
+            expect(currentInView).to.equal(firstQuestion);
         });
 
         it('loads to the proper first page if the form contains only a repeat and nothing outside it', () => {

--- a/test/spec/setvalue.spec.js
+++ b/test/spec/setvalue.spec.js
@@ -488,7 +488,27 @@ describe('setvalue action to populate defaults', () => {
         });
 
         describe('with xforms-value-changed events', () => {
-            it('when the trigger is inside a repeat but the target is not', (done) => {
+            /** @type {import('sinon').SinonSandbox} */
+            let sandbox;
+
+            /** @type {SinonFakeTimers} */
+            let timers;
+
+            beforeEach(() => {
+                sandbox = sinon.createSandbox();
+                timers = sandbox.useFakeTimers();
+            });
+
+            afterEach(() => {
+                timers.runAll();
+
+                timers.clearTimeout();
+                timers.clearInterval();
+                timers.restore();
+                sandbox.restore();
+            });
+
+            it('when the trigger is inside a repeat but the target is not', async () => {
                 const form = loadForm(
                     'setvalue-repeat-tricky-trigger-target.xml'
                 );
@@ -505,11 +525,10 @@ describe('setvalue action to populate defaults', () => {
                 const item3Second = form.view.html.querySelectorAll(sel)[1];
                 form.input.setVal(item3Second, 'd', events.Change());
 
-                setTimeout(() => {
-                    expect(itemX.textContent).not.to.equal('initial default');
-                    expect(hid.textContent).not.to.equal('');
-                    done();
-                }, 100);
+                await timers.runAllAsync();
+
+                expect(itemX.textContent).not.to.equal('initial default');
+                expect(hid.textContent).not.to.equal('');
             });
         });
     });
@@ -541,7 +560,27 @@ describe('setvalue action to populate defaults', () => {
 });
 
 describe('setvalue actions to populate a value if another value changes', () => {
-    it('works outside a repeat in conjunction with a select_minimal', (done) => {
+    /** @type {import('sinon').SinonSandbox} */
+    let sandbox;
+
+    /** @type {SinonFakeTimers} */
+    let timers;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        timers = sandbox.useFakeTimers();
+    });
+
+    afterEach(() => {
+        timers.runAll();
+
+        timers.clearTimeout();
+        timers.clearInterval();
+        timers.restore();
+        sandbox.restore();
+    });
+
+    it('works outside a repeat in conjunction with a select_minimal', async () => {
         const form = loadForm('setvalue.xml');
         form.init();
         const myAgeView = form.view.html.querySelector('[name="/data/my_age"]');
@@ -556,14 +595,13 @@ describe('setvalue actions to populate a value if another value changes', () => 
 
         form.input.setVal(myAgeView, '11', events.Change());
 
-        setTimeout(() => {
-            // expect( myAgeChangedView.textContent ).to.equal( '6' );
-            expect(myAgeChangedModel.textContent).to.equal('111');
-            done();
-        }, 100);
+        await timers.runAllAsync();
+
+        // expect( myAgeChangedView.textContent ).to.equal( '6' );
+        expect(myAgeChangedModel.textContent).to.equal('111');
     });
 
-    it('works inside a repeat in conjunction with a number input', (done) => {
+    it('works inside a repeat in conjunction with a number input', async () => {
         const form = loadForm('setvalue.xml');
         form.init();
         const agesView = [
@@ -589,17 +627,16 @@ describe('setvalue actions to populate a value if another value changes', () => 
 
         form.input.setVal(agesView[0], '22', events.Change());
 
-        setTimeout(() => {
-            // expect( ageChangedsView.map( el => el.textContent )).to.deep.equal( [ 'Age changed!', '' ] );
-            expect(ageChangedsModel.map((el) => el.textContent)).to.deep.equal([
-                'Age changed!',
-                '',
-            ]);
-            done();
-        }, 100);
+        await timers.runAllAsync();
+
+        // expect( ageChangedsView.map( el => el.textContent )).to.deep.equal( [ 'Age changed!', '' ] );
+        expect(ageChangedsModel.map((el) => el.textContent)).to.deep.equal([
+            'Age changed!',
+            '',
+        ]);
     });
 
-    it('works for multiple setvalue actions triggered by same question', (done) => {
+    it('works for multiple setvalue actions triggered by same question', async () => {
         const form = loadForm('setvalue-multiple-under-one.xml');
         form.init();
         const aView = form.input.find('/data/a', 0);
@@ -621,15 +658,14 @@ describe('setvalue actions to populate a value if another value changes', () => 
 
         form.input.setVal(aView, '11', events.Change());
 
-        setTimeout(() => {
-            expect(bModel.textContent).to.equal('2');
-            expect(cView.value).to.equal('11.11');
-            expect(cModel.textContent).to.equal('11.11');
-            expect(dView.value).to.equal('');
-            expect(dModel.textContent).to.equal('');
-            expect(eModel.textContent).to.equal('');
-            done();
-        }, 100);
+        await timers.runAllAsync();
+
+        expect(bModel.textContent).to.equal('2');
+        expect(cView.value).to.equal('11.11');
+        expect(cModel.textContent).to.equal('11.11');
+        expect(dView.value).to.equal('');
+        expect(dModel.textContent).to.equal('');
+        expect(eModel.textContent).to.equal('');
     });
 
     it('works if the setvalue trigger is a calculation', () => {

--- a/test/spec/utils.spec.js
+++ b/test/spec/utils.spec.js
@@ -81,15 +81,13 @@ describe('return postfixed filenames', () => {
         ['myname', undefined, 'myname'],
         ['myname', null, 'myname'],
         ['myname', false, 'myname'],
-    ].forEach((test) => {
-        const file = new Blob(['a'], {
-            type: 'text',
-        });
-        file.name = test[0];
-        const postfix = test[1];
-        const expected = test[2];
+    ].forEach(([name, postfix, expected]) => {
+        it(`returns the filename ${expected} from ${name} and ${postfix}`, () => {
+            const file = new Blob(['a'], {
+                type: 'text',
+            });
+            file.name = name;
 
-        it(`returns the filename ${expected} from ${file.name} and ${postfix}`, () => {
             expect(utils.getFilename(file, postfix)).to.deep.equal(expected);
         });
     });

--- a/test/spec/widget.analog-scale.spec.js
+++ b/test/spec/widget.analog-scale.spec.js
@@ -21,13 +21,22 @@ const FORM_SHOW_SCALE = `<label class="question non-select or-appearance-analog-
 testBasicInstantiation(AnalogScaleWidget, FORM_SHOW_SCALE);
 
 describe('Analog-scale widget with show scale', () => {
-    const fragment = document
-        .createRange()
-        .createContextualFragment(FORM_SHOW_SCALE);
-    new AnalogScaleWidget(fragment.querySelector('input'));
-    const widget = fragment.querySelector('.range-widget');
-    const widgetInput = widget.querySelector('input');
-    const widgetScalesContainer = widget.querySelector('.range-widget__scale');
+    /** @type {HTMLElement} */
+    let widgetInput;
+
+    /** @type {HTMLElement} */
+    let widgetScalesContainer;
+
+    beforeEach(() => {
+        const fragment = document
+            .createRange()
+            .createContextualFragment(FORM_SHOW_SCALE);
+        new AnalogScaleWidget(fragment.querySelector('input'));
+        const widget = fragment.querySelector('.range-widget');
+
+        widgetInput = widget.querySelector('input');
+        widgetScalesContainer = widget.querySelector('.range-widget__scale');
+    });
 
     it('adds widget that contain input with type range', () => {
         expect(widgetInput.type).to.equal('range');

--- a/test/spec/widget.date.spec.js
+++ b/test/spec/widget.date.spec.js
@@ -35,14 +35,21 @@ describe('datepicker widget', () => {
             ['full date', FORM1, '2012-01-01'],
             ['month-year', FORM2, '2012-01'],
             ['year', FORM3, '2012'],
-        ].forEach((t) => {
-            const desc = t[0];
-            const newVal = t[2];
-            const datepicker = initForm(t[1]);
-            const input = datepicker.element;
-            const fakeInput = datepicker.element
-                .closest('.question')
-                .querySelector('.widget input');
+        ].forEach(([desc, form, newVal]) => {
+            /** @type {HTMLElement} */
+            let input;
+
+            /** @type {HTMLElement} */
+            let fakeInput;
+
+            beforeEach(() => {
+                const datepicker = initForm(form);
+
+                input = datepicker.element;
+                fakeInput = datepicker.element
+                    .closest('.question')
+                    .querySelector('.widget input');
+            });
 
             it(`is propagated correctly for ${desc} fields`, () => {
                 input.onchange = sinon.stub().callsFake(() => {});

--- a/test/spec/widget.thousands-sep.spec.js
+++ b/test/spec/widget.thousands-sep.spec.js
@@ -10,9 +10,18 @@ const VALUE = '200';
 runAllCommonWidgetTests(ThousandsSeparatorWidget, FORM, VALUE);
 
 describe('thousands-separator widget', () => {
-    const fragment = document.createRange().createContextualFragment(FORM);
-    const control = fragment.querySelector('input');
-    const widget = new ThousandsSeparatorWidget(control);
+    /** @type {HTMLElement} */
+    let control;
+
+    /** @type {ThousandsSeparatorWidget} */
+    let widget;
+
+    beforeEach(() => {
+        const fragment = document.createRange().createContextualFragment(FORM);
+
+        control = fragment.querySelector('input');
+        widget = new ThousandsSeparatorWidget(control);
+    });
 
     const tests = [
         [1000, '1,000'],

--- a/test/spec/widget.time.spec.js
+++ b/test/spec/widget.time.spec.js
@@ -25,19 +25,21 @@ describe('timepicker widget', () => {
     runAllCommonWidgetTests(Timepicker, FORM, '13:23');
 
     describe('manual input without Enter', () => {
-        const fragment = document.createRange().createContextualFragment(FORM);
-        const control = fragment.querySelector('input');
-        // Note: time zone information is added outside of the widget (in the model)
-        const newVal = '14:01';
-        const timepicker = new Timepicker(control);
-        const fakeInput = timepicker.element
-            .closest('.question')
-            .querySelector('.widget input');
-        const input = timepicker.element
-            .closest('.question')
-            .querySelector('input[type="time"]');
-
         it(`is propagated correctly`, () => {
+            const fragment = document
+                .createRange()
+                .createContextualFragment(FORM);
+            const control = fragment.querySelector('input');
+            // Note: time zone information is added outside of the widget (in the model)
+            const newVal = '14:01';
+            const timepicker = new Timepicker(control);
+            const fakeInput = timepicker.element
+                .closest('.question')
+                .querySelector('.widget input');
+            const input = timepicker.element
+                .closest('.question')
+                .querySelector('input[type="time"]');
+
             input.onchange = sinon.stub().callsFake(() => {});
 
             // add manual value to fake input


### PR DESCRIPTION
- Perform setup/teardown in beforeEach/afterEach rather than in the describe callback
- Use stubs rather than mutating shared values like config
- Use fake timers rather than relying on timeouts to work around async delays
- Style fixes
    - Fix remaining ESLint warnings in affected files
    - Continue to move towards async/await
    - Allow Chai assertion statements