### PR TITLE
fix map with hidden geo-inputs when "hide-input" class is active

### DIFF
--- a/src/widget/geo/geopicker.scss
+++ b/src/widget/geo/geopicker.scss
@@ -557,8 +557,11 @@ $input-button-border: 2px solid #aaaaaa;
             }
         }
 
-        .geo-inputs .geo {
+        .geo-inputs {
             display: none;
+            .geo{
+                display:none
+            }
         }
 
         .toggle-input-type-btn {


### PR DESCRIPTION
fix problem : It was impossible to move or select on the left of map when inputs was hidden