### PR TITLE
Fix: ensure evaluation cascade additions receive form context and update arguments

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -114,9 +114,9 @@ Form.prototype = {
         const { evaluationCascadeAdditions } = this;
 
         if (evaluationCascadeAdditions.length > 0) {
-            baseEvaluationCascade.push(() => {
+            baseEvaluationCascade.push(function (...args) {
                 for (const fn of evaluationCascadeAdditions) {
-                    fn();
+                    fn.apply(this, args);
                 }
             });
         }
@@ -124,8 +124,9 @@ Form.prototype = {
         if (config.experimentalOptimizations.computeAsync) {
             return baseEvaluationCascade.map(
                 (fn) =>
-                    (...args) =>
-                        callOnIdle(() => fn(...args))
+                    function (...args) {
+                        callOnIdle(() => fn.apply(this, args));
+                    }
             );
         }
 


### PR DESCRIPTION
This is a slight variation on #893. The rationale for the difference is [explained here](https://github.com/enketo/enketo-core/pull/893#issuecomment-1132075839).