### PR TITLE
Don't change the zoom when user click on the map

### DIFF
--- a/src/widget/geo/geopicker.js
+++ b/src/widget/geo/geopicker.js
@@ -875,18 +875,12 @@ class Geopicker extends Widget {
      * @param {number} [zoom] - zoom level
      */
     _updateDynamicMapView(latLng, zoom) {
+        this.lastZoom = zoom || this.lastZoom || defaultZoom;
         if (!latLng) {
             this._updatePolyline();
             this._updateMarkers();
-            if (this.points.length === 1 && this.points[0].toString() === '') {
-                if (this.lastLatLng) {
-                    this.map.setView(
-                        this.lastLatLng,
-                        this.lastZoom || defaultZoom
-                    );
-                } else {
-                    this.map.setView(L.latLng(0, 0), zoom || defaultZoom);
-                }
+            if (this.points.length === 1) {
+                this.map.setView( [this.points[0][0], this.points[0][1]], zoom || this.lastZoom || defaultZoom );
             }
         } else {
             this.map.setView(latLng, zoom || defaultZoom);

--- a/src/widget/geo/geopicker.js
+++ b/src/widget/geo/geopicker.js
@@ -880,7 +880,10 @@ class Geopicker extends Widget {
             this._updatePolyline();
             this._updateMarkers();
             if (this.points.length === 1) {
-                this.map.setView( [this.points[0][0], this.points[0][1]], zoom || this.lastZoom || defaultZoom );
+                this.map.setView(
+                    [this.points[0][0], this.points[0][1]],
+                    zoom || this.lastZoom || defaultZoom
+                );
             }
         } else {
             this.map.setView(latLng, zoom || defaultZoom);


### PR DESCRIPTION
With a geo* question, when you click on the map, zoom change to the default zoom (if you are on zoom 19, click on map and zoom change to 15).
This PR suggest not to change the zoom ; just center the map with the new point.