### PR TITLE
Fix: setgeopoint actions correctly identify their affected nodeset

### DIFF
--- a/test/forms/setgeopoint.xml
+++ b/test/forms/setgeopoint.xml
@@ -12,7 +12,10 @@
             <instance>
                 <data id="setgeopoint">
                     <hidden_first_load/>
-                    <visible_first_load/>
+                    <visible_first_load_adjacent_action/>
+                    <visible_first_load_nested_explicit_ref/>
+                    <visible_first_load_nested_implied_ref/>
+                    <visible_first_load_model_action/>
                     <changes/>
                     <location_changed/>
                     <meta>
@@ -22,18 +25,36 @@
             </instance>
 
             <bind nodeset="/data/hidden_first_load" type="string"/>
-            <bind nodeset="/data/visible_first_load" type="string"/>
+            <bind nodeset="/data/visible_first_load_adjacent_action" type="geopoint"/>
+            <bind nodeset="/data/visible_first_load_nested_explicit_ref" type="geopoint"/>
+            <bind nodeset="/data/visible_first_load_nested_implied_ref" type="geopoint"/>
+            <bind nodeset="/data/visible_first_load_model_action" type="geopoint"/>
 
             <bind nodeset="/data/changes" type="int"/>
-            <bind nodeset="/data/location_changed" type="string"/>
+            <bind nodeset="/data/location_changed" type="geopoint"/>
 
             <odk:setgeopoint event="some-unsupported-event odk-instance-first-load" ref="/data/hidden_first_load"/>
+            <odk:setgeopoint event="odk-instance-first-load" ref="/data/visible_first_load_model_action"/>
         </model>
     </h:head>
     <h:body>
-        <odk:setgeopoint event="odk-instance-first-load" ref="/data/visible_first_load"/>
-        <input ref="/data/visible_first_load">
-            <label>odk-instance-first-load</label>
+        <odk:setgeopoint event="odk-instance-first-load" ref="/data/visible_first_load_adjacent_action"/>
+        <input ref="/data/visible_first_load_adjacent_action">
+            <label>visible_first_load_adjacent_action</label>
+        </input>
+
+        <input ref="/data/visible_first_load_nested_explicit_ref">
+            <label>visible_first_load_nested_explicit_ref</label>
+            <odk:setgeopoint event="odk-instance-first-load" ref="/data/visible_first_load_nested_explicit_ref"/>
+        </input>
+
+        <input ref="/data/visible_first_load_nested_implied_ref">
+            <odk:setgeopoint event="odk-instance-first-load"/>
+            <label>visible_first_load_nested_implied_ref</label>
+        </input>
+
+        <input ref="/data/visible_first_load_model_action">
+            <label>visible_first_load_model_action</label>
         </input>
 
         <select1 ref="/data/changes" appearance="minimal">

--- a/test/spec/setgeopoint.spec.js
+++ b/test/spec/setgeopoint.spec.js
@@ -12,6 +12,18 @@ import events from '../../src/js/event';
  */
 
 describe('setgeopoint action', () => {
+    const actionInBodyNodes = {
+        visible_first_load_adjacent_action: 'action defined adjacent to input',
+        visible_first_load_nested_explicit_ref:
+            'action nested in input with explicit ref',
+        visible_first_load_nested_implied_ref:
+            'action nested in input with ref determined by parent',
+    };
+    const firstLoadeNodes = {
+        ...actionInBodyNodes,
+        visible_first_load_model_action: 'action defined in model',
+    };
+
     describe('first load', () => {
         const mock = mockGetCurrentPosition(
             createTestCoordinates({
@@ -37,94 +49,96 @@ describe('setgeopoint action', () => {
                 .then(done, done);
         });
 
-        it('works for questions with odk-instance-first-load inside of the XForms body', (done) => {
-            const form1 = loadForm('setgeopoint.xml');
-            form1.init();
+        for (const [nodeName, description] of Object.entries(
+            actionInBodyNodes
+        )) {
+            it(`works for questions with odk-instance-first-load inside of the XForms body (${description})`, (done) => {
+                const form1 = loadForm('setgeopoint.xml');
+                form1.init();
 
-            mock.lookup
-                .then(({ geopoint }) => {
-                    expect(
-                        form1.model.xml.querySelector('visible_first_load')
-                            .textContent
-                    ).to.equal(geopoint);
-                })
-                .then(done, done);
-        });
+                mock.lookup
+                    .then(({ geopoint }) => {
+                        expect(
+                            form1.model.xml.querySelector(nodeName).textContent
+                        ).to.equal(geopoint);
+                    })
+                    .then(done, done);
+            });
+        }
     });
 
-    describe('null `accuracy`', () => {
-        const mock = mockGetCurrentPosition(
-            createTestCoordinates({
-                latitude: 48.66,
-                longitude: -120.5,
-                altitude: 123,
-            }),
-            { expectLookup: true }
-        );
+    for (const [nodeName, description] of Object.entries(firstLoadeNodes)) {
+        describe(`null 'accuracy' (${description})`, () => {
+            const mock = mockGetCurrentPosition(
+                createTestCoordinates({
+                    latitude: 48.66,
+                    longitude: -120.5,
+                    altitude: 123,
+                }),
+                { expectLookup: true }
+            );
 
-        it('substitutes a null `accuracy` value with 0.0', (done) => {
-            const form1 = loadForm('setgeopoint.xml');
-            form1.init();
+            it('substitutes a null `accuracy` value with 0.0', (done) => {
+                const form1 = loadForm('setgeopoint.xml');
+                form1.init();
 
-            mock.lookup
-                .then(({ geopoint }) => {
-                    expect(
-                        form1.model.xml.querySelector('visible_first_load')
-                            .textContent
-                    ).to.equal(geopoint);
-                    expect(geopoint).to.equal('48.66 -120.5 123 0.0');
-                })
-                .then(done, done);
+                mock.lookup
+                    .then(({ geopoint }) => {
+                        expect(
+                            form1.model.xml.querySelector(nodeName).textContent
+                        ).to.equal(geopoint);
+                        expect(geopoint).to.equal('48.66 -120.5 123 0.0');
+                    })
+                    .then(done, done);
+            });
         });
-    });
 
-    describe('null `altitude`', () => {
-        const mock = mockGetCurrentPosition(
-            createTestCoordinates({
-                latitude: 48.66,
-                longitude: -120.5,
-                accuracy: 2500.12,
-            }),
-            { expectLookup: true }
-        );
+        describe(`null 'altitude' (${description})`, () => {
+            const mock = mockGetCurrentPosition(
+                createTestCoordinates({
+                    latitude: 48.66,
+                    longitude: -120.5,
+                    accuracy: 2500.12,
+                }),
+                { expectLookup: true }
+            );
 
-        it('substitutes a null `altitude` value with 0.0', (done) => {
-            const form1 = loadForm('setgeopoint.xml');
-            form1.init();
+            it('substitutes a null `altitude` value with 0.0', (done) => {
+                const form1 = loadForm('setgeopoint.xml');
+                form1.init();
 
-            mock.lookup
-                .then(({ geopoint }) => {
-                    expect(
-                        form1.model.xml.querySelector('visible_first_load')
-                            .textContent
-                    ).to.equal(geopoint);
-                    expect(geopoint).to.include('48.66 -120.5 0.0 2500.12');
-                })
-                .then(done, done);
+                mock.lookup
+                    .then(({ geopoint }) => {
+                        expect(
+                            form1.model.xml.querySelector(nodeName).textContent
+                        ).to.equal(geopoint);
+                        expect(geopoint).to.include('48.66 -120.5 0.0 2500.12');
+                    })
+                    .then(done, done);
+            });
         });
-    });
 
-    describe('lookup failure', () => {
-        const mock = mockGetCurrentPosition(
-            createGeolocationLookupError('PERMISSION_DENIED'),
-            { expectLookup: true }
-        );
+        describe(`lookup failure (${description})`, () => {
+            const mock = mockGetCurrentPosition(
+                createGeolocationLookupError('PERMISSION_DENIED'),
+                { expectLookup: true }
+            );
 
-        it('sets an empty string when lookup fails', (done) => {
-            const form1 = loadForm('setgeopoint.xml');
-            form1.init();
+            it('sets an empty string when lookup fails', (done) => {
+                const form1 = loadForm('setgeopoint.xml');
+                form1.init();
 
-            mock.lookup
-                .then(({ geopoint }) => {
-                    expect(
-                        form1.model.xml.querySelector('visible_first_load')
-                            .textContent
-                    ).to.equal(geopoint);
-                    expect(geopoint).to.include('');
-                })
-                .then(done, done);
+                mock.lookup
+                    .then(({ geopoint }) => {
+                        expect(
+                            form1.model.xml.querySelector(nodeName).textContent
+                        ).to.equal(geopoint);
+                        expect(geopoint).to.include('');
+                    })
+                    .then(done, done);
+            });
         });
-    });
+    }
 });
 
 describe('setgeopoint actions to populate a value if another value changes', () => {


### PR DESCRIPTION
Current behavior:

1. Actions defined in the model, or in the body *adjacent* its input, populate the model correctly.
2. Actions nested within their input, with an explicit `ref` attribute, fail to update the view. This is because there is a hidden HTML input representing the action (distinct from the input representing the model value), which the current behavior selects.
3. Actions nested within their input, *without* an explicit `ref` attribute, replace the entire descendant tree of the model with the geopoint value. The cause is identical to the explicit-ref case, but the erroneously selected input has no `name` attribute. This causes the model update, in `Nodeset.setVal`, to evaluate against a nodeset resolving to the root `data` node.

A couple open questions:

1. Should the third case described above _ever_ be allowed to happen? My instinct is that we should never allow calling `setVal` on a node with children.

2. How does this affect performance? It's definitely doing more work. It seems fine on my obviously small test form, but I'm not sure how much it'll impact larger or more complex forms.