### PR TITLE
Use of Native Xpath - Faster calculate when big data

### DIFF
--- a/src/js/form-model.js
+++ b/src/js/form-model.js
@@ -1561,44 +1561,18 @@ FormModel.prototype.evaluate = function (
     }
 
     // try native to see if that works... (will not work if the expr contains custom OpenRosa functions)
-    if (
-        tryNative &&
-        typeof doc.evaluate !== 'undefined' &&
-        !OPENROSA.test(expr)
-    ) {
+    try {
+        // console.log( 'trying the blazing fast native XPath Evaluator for', expr, index );
+        result = doc.evaluate( expr, context, this.getNsResolver(), resTypeNum, null );
+    } catch {
         try {
-            // console.log( 'trying the blazing fast native XPath Evaluator for', expr, index );
-            result = doc.evaluate(
-                expr,
-                context,
-                this.getNsResolver(),
-                resTypeNum,
-                null
-            );
-        } catch (e) {
-            // console.log( '%cWell native XPath evaluation did not work... No worries, worth a shot, the expression probably ' +
-            //    'contained unknown OpenRosa functions or errors:', expr );
-        }
-    }
-
-    // if that didn't work, try the slow XPathJS evaluator
-    if (!result) {
-        try {
-            if (typeof doc.jsEvaluate === 'undefined') {
+            if ( typeof doc.jsEvaluate === 'undefined' ) {
                 this.bindJsEvaluator();
             }
             // console.log( 'trying the slow enketo-xpathjs "openrosa" evaluator for', expr, index );
-            result = doc.jsEvaluate(
-                expr,
-                context,
-                this.getNsResolver(),
-                resTypeNum,
-                null
-            );
-        } catch (e) {
-            throw new FormLogicError(
-                `Could not evaluate: ${expr}, message: ${e.message}`
-            );
+            result = doc.jsEvaluate( expr, context, this.getNsResolver(), resTypeNum, null );
+        } catch ( e ) {
+            throw new FormLogicError( `Could not evaluate: ${expr}, message: ${e.message}` );
         }
     }
 


### PR DESCRIPTION
If you create a form with select_one_from_file based on big csv file (more than 3000 rows and 10 columns), then you make ten calculate for each columns, it will be very slow. (the select_one was filtered by an other question).

_Exemple : In France, we have 34 000 communes, we can filter it with region and department._

Trying to always use Xpath native approach improve the value search when model are big.
If expr contains custom OpenRosa functions, it will use the fork as expected (jsEvaluate) which is slower than the native method.

