### PR TITLE
Prepare v6.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.1.2] - 2022-06-24
+
+-   Update meta selector used when setting deprecatedID (#900)
+-   Preserve geopicker zoom, center map on user location on load, no error clicking pin (#905)
+-   Don't use removed repeat instance as context for relevance (#909)
+
 ## [6.1.1] - 2022-06-01
 
 -   Fix: rendering unexpected geopoint widget for setvalue actions within an input (#896)

--- a/docs/Geopicker.html
+++ b/docs/Geopicker.html
@@ -411,7 +411,7 @@ This form control is often hidden by the widget.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1499">line 1499</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1508">line 1508</a>
     </li></ul></dd>
     
 
@@ -557,7 +557,7 @@ This form control is often hidden by the widget.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1520">line 1520</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1529">line 1529</a>
     </li></ul></dd>
     
 
@@ -882,7 +882,7 @@ This form control is often hidden by the widget.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line793">line 793</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line792">line 792</a>
     </li></ul></dd>
     
 
@@ -987,7 +987,7 @@ This form control is often hidden by the widget.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1270">line 1270</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1279">line 1279</a>
     </li></ul></dd>
     
 
@@ -1296,7 +1296,7 @@ This form control is often hidden by the widget.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1316">line 1316</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1325">line 1325</a>
     </li></ul></dd>
     
 
@@ -1383,7 +1383,7 @@ This form control is often hidden by the widget.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1385">line 1385</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1394">line 1394</a>
     </li></ul></dd>
     
 
@@ -1649,7 +1649,7 @@ It only extracts the value of the first <coordinates> element or, if <coordinate
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1283">line 1283</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1292">line 1292</a>
     </li></ul></dd>
     
 
@@ -1985,7 +1985,7 @@ This only changes the map view. It does not record geopoints.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1043">line 1043</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1052">line 1052</a>
     </li></ul></dd>
     
 
@@ -2139,7 +2139,7 @@ This only changes the map view. It does not record geopoints.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1024">line 1024</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1033">line 1033</a>
     </li></ul></dd>
     
 
@@ -2293,7 +2293,7 @@ This only changes the map view. It does not record geopoints.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line960">line 960</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line969">line 969</a>
     </li></ul></dd>
     
 
@@ -2474,7 +2474,7 @@ This only changes the map view. It does not record geopoints.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line908">line 908</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line917">line 917</a>
     </li></ul></dd>
     
 
@@ -2583,7 +2583,7 @@ This only changes the map view. It does not record geopoints.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line938">line 938</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line947">line 947</a>
     </li></ul></dd>
     
 
@@ -2878,7 +2878,7 @@ This only changes the map view. It does not record geopoints.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line977">line 977</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line986">line 986</a>
     </li></ul></dd>
     
 
@@ -3735,7 +3735,7 @@ invalid geopoints in a list of geopoints (the form controller only validates the
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line995">line 995</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1004">line 1004</a>
     </li></ul></dd>
     
 
@@ -4068,7 +4068,7 @@ script is only requested once.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1300">line 1300</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1309">line 1309</a>
     </li></ul></dd>
     
 
@@ -4291,7 +4291,7 @@ script is only requested once.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line899">line 899</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line908">line 908</a>
     </li></ul></dd>
     
 
@@ -4510,7 +4510,7 @@ script is only requested once.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1244">line 1244</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1253">line 1253</a>
     </li></ul></dd>
     
 
@@ -4646,7 +4646,7 @@ script is only requested once.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line877">line 877</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line886">line 886</a>
     </li></ul></dd>
     
 
@@ -4824,7 +4824,7 @@ script is only requested once.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1362">line 1362</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1371">line 1371</a>
     </li></ul></dd>
     
 
@@ -5189,7 +5189,7 @@ or update any markers, polylines, or polygons.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1056">line 1056</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1065">line 1065</a>
     </li></ul></dd>
     
 
@@ -5276,7 +5276,7 @@ or update any markers, polylines, or polygons.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1208">line 1208</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1217">line 1217</a>
     </li></ul></dd>
     
 
@@ -5364,7 +5364,7 @@ A polygon is a type of polyline. This function is ALWAYS called by _updatePolyli
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1150">line 1150</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1159">line 1159</a>
     </li></ul></dd>
     
 
@@ -5560,7 +5560,7 @@ A polygon is a type of polyline. This function is ALWAYS called by _updatePolyli
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1488">line 1488</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1497">line 1497</a>
     </li></ul></dd>
     
 
@@ -5761,7 +5761,7 @@ A polygon is a type of polyline. This function is ALWAYS called by _updatePolyli
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1602">line 1602</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1611">line 1611</a>
     </li></ul></dd>
     
 
@@ -5853,7 +5853,7 @@ A polygon is a type of polyline. This function is ALWAYS called by _updatePolyli
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1581">line 1581</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1590">line 1590</a>
     </li></ul></dd>
     
 
@@ -5945,7 +5945,7 @@ A polygon is a type of polyline. This function is ALWAYS called by _updatePolyli
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1618">line 1618</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1627">line 1627</a>
     </li></ul></dd>
     
 
@@ -6037,7 +6037,7 @@ A polygon is a type of polyline. This function is ALWAYS called by _updatePolyli
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1422">line 1422</a>
+        <a href="widget_geo_geopicker.js.html">widget/geo/geopicker.js</a>, <a href="widget_geo_geopicker.js.html#line1431">line 1431</a>
     </li></ul></dd>
     
 

--- a/docs/Nodeset.html
+++ b/docs/Nodeset.html
@@ -342,7 +342,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line282">line 282</a>
+        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line283">line 283</a>
     </li></ul></dd>
     
 
@@ -981,7 +981,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line388">line 388</a>
+        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line389">line 389</a>
     </li></ul></dd>
     
 
@@ -1592,7 +1592,7 @@ otherwise an object with update information is returned.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line304">line 304</a>
+        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line305">line 305</a>
     </li></ul></dd>
     
 
@@ -1792,7 +1792,7 @@ otherwise an object with update information is returned.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line335">line 335</a>
+        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line336">line 336</a>
     </li></ul></dd>
     
 
@@ -1995,7 +1995,7 @@ otherwise an object with update information is returned.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line406">line 406</a>
+        <a href="js_nodeset.js.html">js/nodeset.js</a>, <a href="js_nodeset.js.html#line407">line 407</a>
     </li></ul></dd>
     
 

--- a/docs/js_form-model.js.html
+++ b/docs/js_form-model.js.html
@@ -709,7 +709,7 @@ FormModel.prototype.setInstanceIdAndDeprecatedId = function () {
                 'text/xml'
             ).documentElement;
             this.xml.adoptNode(deprecatedIdEl);
-            metaEl = this.xml.querySelector('* > meta');
+            metaEl = this.xml.querySelector('instance > * > meta');
             metaEl.appendChild(deprecatedIdEl);
         }
     }

--- a/docs/js_nodeset.js.html
+++ b/docs/js_nodeset.js.html
@@ -295,6 +295,7 @@ Nodeset.prototype.remove = function () {
                 nodes: null,
                 repeatPath,
                 repeatIndex,
+                removed: true, // Introduced to handle relevance on model nodes with no form controls (calculates)
             })
         );
 

--- a/docs/js_relevant.js.html
+++ b/docs/js_relevant.js.html
@@ -252,8 +252,16 @@ export default {
              */
             let context = p.path;
             if (
-                getChild(node, `.or-repeat-info[data-name="${p.path}"]`) &amp;&amp;
-                !getChild(node, `.or-repeat[name="${p.path}"]`)
+                (getChild(node, `.or-repeat-info[data-name="${p.path}"]`) &amp;&amp;
+                    !getChild(node, `.or-repeat[name="${p.path}"]`)) ||
+                // Special cases below for model nodes with no visible form control: if repeat instance removed or if
+                // no instances at all (e.g. during load with `jr:count="0"`)
+                (insideRepeat &amp;&amp;
+                    repeatParent == null &amp;&amp;
+                    (options.removed ||
+                        this.form.view.html.querySelector(
+                            `.or-repeat[name="${CSS.escape(repeatPath)}"]`
+                        ) == null))
             ) {
                 context = null;
             }

--- a/docs/module-relevant.html
+++ b/docs/module-relevant.html
@@ -435,7 +435,7 @@ when <code>config.excludeNonRelevant</code> is off.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line605">line 605</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line613">line 613</a>
     </li></ul></dd>
     
 
@@ -572,7 +572,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line558">line 558</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line566">line 566</a>
     </li></ul></dd>
     
 
@@ -732,7 +732,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line614">line 614</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line622">line 622</a>
     </li></ul></dd>
     
 
@@ -869,7 +869,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line527">line 527</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line535">line 535</a>
     </li></ul></dd>
     
 
@@ -1096,7 +1096,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line491">line 491</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line499">line 499</a>
     </li></ul></dd>
     
 
@@ -1300,7 +1300,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line285">line 285</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line293">line 293</a>
     </li></ul></dd>
     
 
@@ -1504,7 +1504,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line304">line 304</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line312">line 312</a>
     </li></ul></dd>
     
 
@@ -1778,7 +1778,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line323">line 323</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line331">line 331</a>
     </li></ul></dd>
     
 
@@ -1936,7 +1936,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line583">line 583</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line591">line 591</a>
     </li></ul></dd>
     
 
@@ -2091,7 +2091,7 @@ This function is separated so it can be overridden in custom apps.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line352">line 352</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line360">line 360</a>
     </li></ul></dd>
     
 
@@ -2996,7 +2996,7 @@ in certain cases.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line341">line 341</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line349">line 349</a>
     </li></ul></dd>
     
 
@@ -3130,7 +3130,7 @@ in certain cases.</p>
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line330">line 330</a>
+        <a href="js_relevant.js.html">js/relevant.js</a>, <a href="js_relevant.js.html#line338">line 338</a>
     </li></ul></dd>
     
 

--- a/docs/widget_geo_geopicker.js.html
+++ b/docs/widget_geo_geopicker.js.html
@@ -89,15 +89,15 @@ let searchSource =
     'https://maps.googleapis.com/maps/api/geocode/json?address={address}&amp;sensor=true&amp;key={api_key}';
 const googleApiKey = config.googleApiKey || config.google_api_key;
 const iconSingle = L.divIcon({
-    iconSize: 24,
+    iconSize: [16, 24],
     className: 'enketo-geopoint-marker',
 });
 const iconMulti = L.divIcon({
-    iconSize: 16,
+    iconSize: [16, 16],
     className: 'enketo-geopoint-circle-marker',
 });
 const iconMultiActive = L.divIcon({
-    iconSize: 16,
+    iconSize: [16, 16],
     className: 'enketo-geopoint-circle-marker-active',
 });
 
@@ -374,7 +374,7 @@ class Geopicker extends Widget {
             this._updateMap([0, 0], 1);
             if (this.props.detect) {
                 getCurrentPosition()
-                    .then((position) => {
+                    .then(({ position }) => {
                         that._updateMap(
                             [
                                 position.coords.latitude,
@@ -822,7 +822,6 @@ class Geopicker extends Widget {
         // update last requested map coordinates to be used to initialize map in mobile fullscreen view
         if (latLng) {
             this.lastLatLng = latLng;
-            this.lastZoom = zoom;
         }
 
         // update the map if it is visible
@@ -888,6 +887,16 @@ class Geopicker extends Widget {
                     // do nothing if the field has a current marker
                     // instead the user will have to drag to change it by map
                 }
+            });
+
+            this.map.on('load', () => {
+                this.map.on('zoomend', (event) => {
+                    const zoom = event.target.getZoom();
+
+                    if (zoom != null) {
+                        this.lastZoom = zoom;
+                    }
+                });
             });
 
             // watch out, default "Leaflet" link clicks away from page, loosing all data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-core",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-core",
     "description": "Extensible Enketo form engine",
     "homepage": "https://enketo.org",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "license": "Apache-2.0",
     "os": [
         "darwin",


### PR DESCRIPTION
I did not update dependencies. I think we should update the release instructions to say we usually don't for point releases. It seems too risky to me -- we won't do any QA on patches typically.

I did take a quick look to see whether anything was high severity. https://github.com/chalk/ansi-regex/pull/37 is marked as high severity but it seems... not even kind of? 