### PR TITLE
fix toggle or-appearance-compact with dynamic nesteed repeat group

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -1050,7 +1050,7 @@ Form.prototype.setEventHandlers = function () {
         this.output.update();
     });
 
-    this.view.$.on('click', '.or-group > h4', function() {
+    this.view.$.on('click', '.or-group > h4', function () {
         // The resize trigger is to make sure canvas widgets start working.
         $(this)
             .closest('.or-group')

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -1050,7 +1050,7 @@ Form.prototype.setEventHandlers = function () {
         this.output.update();
     });
 
-    this.view.$.find('.or-group > h4').on('click', function () {
+    this.view.$.on('click', '.or-group > h4', function() {
         // The resize trigger is to make sure canvas widgets start working.
         $(this)
             .closest('.or-group')


### PR DESCRIPTION
If you have a nested repeat group, `this.view.$.find('.or-group > h4').on('click', function () [...] ` is not triggered on the dynamic add group.
In this example :
![image](https://user-images.githubusercontent.com/38976316/182188751-810ad9fd-5efb-4627-9648-4de110ecc140.png)

At first I have 1 parent repeat group with 1 child repeat group.
I add a parent repeat group.
I can't click on the h4 of the second child repeat group to compact it