### PR TITLE
Fix timepicker in Finnish locales

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -14,6 +14,7 @@ import {
     closestAncestorUntil,
     getSiblingElement,
 } from './dom-utils';
+import { initTimeLocalization } from './format';
 import inputHelper from './input';
 import repeatModule from './repeat';
 import tocModule from './toc';
@@ -262,6 +263,8 @@ Form.prototype.addModule = function (module) {
 Form.prototype.init = function () {
     let loadErrors = [];
     const that = this;
+
+    initTimeLocalization(this.view.html);
 
     this.toc = this.addModule(tocModule);
     this.pages = this.addModule(pageModule);

--- a/src/js/format.js
+++ b/src/js/format.js
@@ -9,7 +9,7 @@ import events from './event';
  * @property {string[]} locales
  * @property {string} dateString
  * @property {string} timeString
- * @property {string[]} timeFormatter
+ * @property {Intl.DateTimeFormat} timeFormatter
  */
 
 /** @type {LocaleState | null} */
@@ -57,7 +57,6 @@ const initTimeLocalization = (rootElement) => {
  * @namespace time
  */
 const time = {
-    // For now we just look at a subset of numbers in Arabic and Latin. There are actually over 20 number scripts and :digit: doesn't work in browsers
     /**
      * @type {boolean}
      */
@@ -102,15 +101,7 @@ const time = {
      * @param {string} time - Time string
      */
     hasMeridian(time) {
-        try {
-            const date = new Date(
-                localeState.dateString.replace(localeState.timeString, time)
-            );
-
-            return this.meridianNotation(date) != null;
-        } catch (error) {
-            return false;
-        }
+        return time.includes(this.amNotation) || time.includes(this.pmNotation);
     },
 };
 

--- a/src/js/format.js
+++ b/src/js/format.js
@@ -2,6 +2,8 @@
  * @module format
  */
 
+import events from './event';
+
 /**
  * @typedef LocaleState
  * @property {string[]} locales
@@ -10,8 +12,8 @@
  * @property {string[]} timeFormatter
  */
 
-/** @type {LocaleState} */
-let localeState;
+/** @type {LocaleState | null} */
+let localeState = null;
 
 const setLocalizedTimeFormatter = () => {
     const locales = Intl.getCanonicalLocales(navigator.languages);
@@ -28,17 +30,28 @@ const setLocalizedTimeFormatter = () => {
         timeString,
         timeFormatter,
     };
-
-    const updateTimeFormatter = () => {
-        removeEventListener('languagechange', updateTimeFormatter);
-
-        setLocalizedTimeFormatter();
-    };
-
-    addEventListener('languagechange', updateTimeFormatter);
 };
 
-setLocalizedTimeFormatter();
+/**
+ * @param {HTMLFormElement} [rootElement]
+ */
+const initTimeLocalization = (rootElement) => {
+    const languageChangeListener = () => {
+        setLocalizedTimeFormatter();
+
+        rootElement?.dispatchEvent(events.ChangeLanguage());
+    };
+
+    addEventListener('languagechange', languageChangeListener);
+
+    setLocalizedTimeFormatter();
+
+    return removeEventListener.bind(
+        window,
+        'languagechange',
+        languageChangeListener
+    );
+};
 
 /**
  * @namespace time
@@ -101,4 +114,4 @@ const time = {
     },
 };
 
-export { time };
+export { initTimeLocalization, time };

--- a/src/widget/datetime/datetimepicker-extended.js
+++ b/src/widget/datetime/datetimepicker-extended.js
@@ -154,6 +154,7 @@ class DatetimepickerExtended extends Widget {
                       )
                     : '';
         }
+
         if (val !== this.value) {
             const vals = val.split('T');
             const dateVal = vals[0];
@@ -163,6 +164,8 @@ class DatetimepickerExtended extends Widget {
             this.$fakeDateI.datepicker('setDate', dateVal);
             this.$fakeTimeI.timepicker('setTime', timeVal);
         }
+
+        this.$fakeTimeI.timepicker('updateLocalization');
     }
 
     get originalInputValue() {

--- a/src/widget/time/timepicker-extended.js
+++ b/src/widget/time/timepicker-extended.js
@@ -82,8 +82,14 @@ class TimepickerExtended extends Widget {
      * Updates widget
      */
     update() {
-        if (this.element.value !== this.value && this.fakeTimeI) {
-            $(this.fakeTimeI).timepicker('setTime', this.element.value);
+        if (this.fakeTimeI) {
+            const $fakeTimeInput = $(this.fakeTimeI);
+
+            if (this.element.value !== this.value) {
+                $fakeTimeInput.timepicker('setTime', this.element.value);
+            }
+
+            $fakeTimeInput.timepicker('updateLocalization');
         }
     }
 

--- a/src/widget/time/timepicker.js
+++ b/src/widget/time/timepicker.js
@@ -1,5 +1,7 @@
 import $ from 'jquery';
 import event from '../../js/event';
+import { time } from '../../js/format';
+
 /*!
  * Timepicker
  *
@@ -16,6 +18,7 @@ import event from '../../js/event';
 (($, window, document) => {
     // TIMEPICKER PUBLIC CLASS DEFINITION
     const Timepicker = function (element, options) {
+        this.languages = navigator.languages;
         this.widget = '';
         this.$element = $(element);
         this.defaultTime = options.defaultTime;
@@ -27,8 +30,6 @@ import event from '../../js/event';
         this.secondStep = options.secondStep;
         this.snapToStep = options.snapToStep;
         this.showInputs = options.showInputs;
-        this.showMeridian = options.showMeridian;
-        this.meridianNotation = options.meridianNotation;
         this.showSeconds = options.showSeconds;
         this.template = options.template;
         this.appendWidgetTo = options.appendWidgetTo;
@@ -56,6 +57,17 @@ import event from '../../js/event';
     };
 
     Timepicker.prototype = {
+        get showMeridian() {
+            return time.hour12;
+        },
+
+        get meridianNotation() {
+            return {
+                am: time.amNotation,
+                pm: time.pmNotation,
+            };
+        },
+
         constructor: Timepicker,
         _init() {
             const self = this;
@@ -109,6 +121,9 @@ import event from '../../js/event';
                     'click',
                     $.proxy(this.widgetClick, this)
                 );
+
+                this.meridianColumns =
+                    this.$widget[0].querySelectorAll('.meridian-column');
             } else {
                 this.$widget = false;
             }
@@ -356,19 +371,13 @@ import event from '../../js/event';
                 this.showSeconds
                     ? `<td class="separator">&nbsp;</td><td><a href="#" data-action="incrementSecond"><span class="${this.icons.up}"></span></a></td>`
                     : ''
-            }${
-                this.showMeridian
-                    ? `<td class="separator">&nbsp;</td><td class="meridian-column"><a href="#" data-action="toggleMeridian"><span class="${this.icons.up}"></span></a></td>`
-                    : ''
-            }</tr><tr><td>${hourTemplate}</td> <td class="separator">:</td><td>${minuteTemplate}</td> ${
+            }<td class="separator meridian-column">&nbsp;</td><td class="meridian-column"><a href="#" data-action="toggleMeridian"><span class="${
+                this.icons.up
+            }"></span></a></td></tr><tr><td>${hourTemplate}</td> <td class="separator">:</td><td>${minuteTemplate}</td> ${
                 this.showSeconds
                     ? `<td class="separator">:</td><td>${secondTemplate}</td>`
                     : ''
-            }${
-                this.showMeridian
-                    ? `<td class="separator">&nbsp;</td><td>${meridianTemplate}</td>`
-                    : ''
-            }</tr><tr><td><a href="#" data-action="decrementHour"><span class="${
+            }<td class="separator meridian-column">&nbsp;</td><td class="meridian-column">${meridianTemplate}</td></tr><tr><td><a href="#" data-action="decrementHour"><span class="${
                 this.icons.down
             }"></span></a></td><td class="separator"></td><td><a href="#" data-action="decrementMinute"><span class="${
                 this.icons.down
@@ -376,11 +385,9 @@ import event from '../../js/event';
                 this.showSeconds
                     ? `<td class="separator">&nbsp;</td><td><a href="#" data-action="decrementSecond"><span class="${this.icons.down}"></span></a></td>`
                     : ''
-            }${
-                this.showMeridian
-                    ? `<td class="separator">&nbsp;</td><td><a href="#" data-action="toggleMeridian"><span class="${this.icons.down}"></span></a></td>`
-                    : ''
-            }</tr></table>`;
+            }<td class="separator meridian-column">&nbsp;</td><td class="meridian-column"><a href="#" data-action="toggleMeridian"><span class="${
+                this.icons.down
+            }"></span></a></td></tr></table>`;
 
             switch (this.template) {
                 case 'dropdown':
@@ -1170,6 +1177,21 @@ import event from '../../js/event';
                         .find('span.timepicker-meridian')
                         .text(this.meridian);
                 }
+            }
+
+            const { showMeridian } = this;
+            const meridianDisplay = showMeridian ? 'table-cell' : 'none';
+
+            this.meridianColumns.forEach((column) => {
+                column.style.display = meridianDisplay;
+            });
+        },
+
+        updateLocalization() {
+            if (this.languages !== navigator.languages) {
+                this.languages = navigator.languages;
+                this.updateFromElementVal();
+                this.updateWidget();
             }
         },
 

--- a/test/spec/format.spec.js
+++ b/test/spec/format.spec.js
@@ -1,4 +1,4 @@
-import { time } from '../../src/js/format';
+import { initTimeLocalization, time } from '../../src/js/format';
 
 describe('Format', () => {
     /** @type {import('sinon').SinonSandbox} */
@@ -51,16 +51,20 @@ describe('Format', () => {
         },
     ].forEach(({ locale, hour12, am, pm }) => {
         describe(`time determination for ${locale}`, () => {
+            /** @type {Function} */
+            let teeardownTimeLocalization;
+
             beforeEach(() => {
                 sandbox = sinon.createSandbox();
 
                 sandbox.stub(navigator, 'languages').get(() => [locale]);
-                dispatchEvent(new Event('languagechange'));
+
+                teeardownTimeLocalization = initTimeLocalization();
             });
 
             afterEach(() => {
                 sandbox.restore();
-                dispatchEvent(new Event('languagechange'));
+                teeardownTimeLocalization();
             });
 
             it(`identifies ${locale} time meridian notation as ${hour12}`, () => {

--- a/test/spec/format.spec.js
+++ b/test/spec/format.spec.js
@@ -49,31 +49,48 @@ describe('Format', () => {
             am: null,
             pm: null,
         },
+        {
+            locale: 'fi',
+            hour12: false,
+            am: null,
+            pm: null,
+        },
     ].forEach(({ locale, hour12, am, pm }) => {
         describe(`time determination for ${locale}`, () => {
             /** @type {Function} */
-            let teeardownTimeLocalization;
+            let teardownTimeLocalization;
 
             beforeEach(() => {
                 sandbox = sinon.createSandbox();
 
                 sandbox.stub(navigator, 'languages').get(() => [locale]);
 
-                teeardownTimeLocalization = initTimeLocalization();
+                teardownTimeLocalization = initTimeLocalization();
             });
 
             afterEach(() => {
                 sandbox.restore();
-                teeardownTimeLocalization();
+                teardownTimeLocalization();
             });
 
             it(`identifies ${locale} time meridian notation as ${hour12}`, () => {
-                expect(time.hour12).to.equal(hour12);
+                expect(time.hour12).to.equal(hour12, locale);
             });
 
             it(`extracts the AM and PM notation for as: ${am}, ${pm}`, () => {
-                expect(time.amNotation).to.equal(am);
+                expect(time.amNotation).to.equal(am, locale);
                 expect(time.pmNotation).to.equal(pm);
+            });
+
+            it('determines whether a localized time string has a meridian', () => {
+                const date = new Date(2022, 8, 27, 1, 2, 3, 4);
+                const timeStr = date.toLocaleTimeString([locale]);
+                const expected = am != null;
+
+                expect(time.hasMeridian(timeStr)).to.equal(
+                    expected,
+                    `${locale}, ${timeStr}, ${date.toLocaleString([locale])}`
+                );
             });
         });
     });

--- a/test/spec/types.spec.js
+++ b/test/spec/types.spec.js
@@ -9,14 +9,14 @@ describe('Types', () => {
     describe('time', () => {
         describe('meridian convertor', () => {
             /** @type {Function} */
-            let teeardownTimeLocalization;
+            let teardownTimeLocalization;
 
             beforeEach(() => {
-                teeardownTimeLocalization = initTimeLocalization();
+                teardownTimeLocalization = initTimeLocalization();
             });
 
             afterEach(() => {
-                teeardownTimeLocalization();
+                teardownTimeLocalization();
             });
 
             [

--- a/test/spec/types.spec.js
+++ b/test/spec/types.spec.js
@@ -1,3 +1,4 @@
+import { initTimeLocalization } from '../../src/js/format';
 import types from '../../src/js/types';
 
 /*
@@ -7,6 +8,17 @@ import types from '../../src/js/types';
 describe('Types', () => {
     describe('time', () => {
         describe('meridian convertor', () => {
+            /** @type {Function} */
+            let teeardownTimeLocalization;
+
+            beforeEach(() => {
+                teeardownTimeLocalization = initTimeLocalization();
+            });
+
+            afterEach(() => {
+                teeardownTimeLocalization();
+            });
+
             [
                 ['12:03 PM', '12:03'],
                 ['01:03 PM', '13:03'],

--- a/test/spec/widget.datetime.spec.js
+++ b/test/spec/widget.datetime.spec.js
@@ -1,3 +1,4 @@
+import { initTimeLocalization } from '../../src/js/format';
 import Datetimepicker from '../../src/widget/datetime/datetimepicker-extended';
 import { runAllCommonWidgetTests } from '../helpers/test-widget';
 
@@ -14,12 +15,17 @@ describe('datetimepicker widget', () => {
     /** @type {import('sinon').SinonSandbox} */
     let sandbox;
 
+    /** @type {Function} */
+    let teeardownTimeLocalization;
+
     beforeEach(() => {
         sandbox = sinon.createSandbox();
+        teeardownTimeLocalization = initTimeLocalization();
     });
 
     afterEach(() => {
         sandbox.restore();
+        teeardownTimeLocalization();
     });
 
     function initForm(form) {

--- a/test/spec/widget.datetime.spec.js
+++ b/test/spec/widget.datetime.spec.js
@@ -16,16 +16,16 @@ describe('datetimepicker widget', () => {
     let sandbox;
 
     /** @type {Function} */
-    let teeardownTimeLocalization;
+    let teardownTimeLocalization;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
-        teeardownTimeLocalization = initTimeLocalization();
+        teardownTimeLocalization = initTimeLocalization();
     });
 
     afterEach(() => {
         sandbox.restore();
-        teeardownTimeLocalization();
+        teardownTimeLocalization();
     });
 
     function initForm(form) {

--- a/test/spec/widget.time.spec.js
+++ b/test/spec/widget.time.spec.js
@@ -1,6 +1,5 @@
 import Timepicker from '../../src/widget/time/timepicker-extended';
 import { runAllCommonWidgetTests } from '../helpers/test-widget';
-import { format } from '../../src/js/format';
 
 const FORM = `
     <form class="or">
@@ -15,11 +14,13 @@ describe('timepicker widget', () => {
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
-        sandbox.stub(format, 'locale').get(() => 'nl');
+        sandbox.stub(navigator, 'languages').get(() => ['nl']);
+        dispatchEvent(new Event('languagechange'));
     });
 
     afterEach(() => {
         sandbox.restore();
+        dispatchEvent(new Event('languagechange'));
     });
 
     runAllCommonWidgetTests(Timepicker, FORM, '13:23');

--- a/test/spec/widget.time.spec.js
+++ b/test/spec/widget.time.spec.js
@@ -1,3 +1,4 @@
+import { initTimeLocalization } from '../../src/js/format';
 import Timepicker from '../../src/widget/time/timepicker-extended';
 import { runAllCommonWidgetTests } from '../helpers/test-widget';
 
@@ -12,15 +13,21 @@ describe('timepicker widget', () => {
     /** @type {import('sinon').SinonSandbox} */
     let sandbox;
 
+    /** @type {Function} */
+    let teeardownTimeLocalization;
+
     beforeEach(() => {
         sandbox = sinon.createSandbox();
-        sandbox.stub(navigator, 'languages').get(() => ['nl']);
-        dispatchEvent(new Event('languagechange'));
+
+        const languages = ['nl'];
+
+        sandbox.stub(navigator, 'languages').get(() => languages);
+        teeardownTimeLocalization = initTimeLocalization();
     });
 
     afterEach(() => {
+        teeardownTimeLocalization();
         sandbox.restore();
-        dispatchEvent(new Event('languagechange'));
     });
 
     runAllCommonWidgetTests(Timepicker, FORM, '13:23');

--- a/test/spec/widget.time.spec.js
+++ b/test/spec/widget.time.spec.js
@@ -14,7 +14,7 @@ describe('timepicker widget', () => {
     let sandbox;
 
     /** @type {Function} */
-    let teeardownTimeLocalization;
+    let teardownTimeLocalization;
 
     beforeEach(() => {
         sandbox = sinon.createSandbox();
@@ -22,11 +22,11 @@ describe('timepicker widget', () => {
         const languages = ['nl'];
 
         sandbox.stub(navigator, 'languages').get(() => languages);
-        teeardownTimeLocalization = initTimeLocalization();
+        teardownTimeLocalization = initTimeLocalization();
     });
 
     afterEach(() => {
-        teeardownTimeLocalization();
+        teardownTimeLocalization();
         sandbox.restore();
     });
 


### PR DESCRIPTION
Fixes enketo/enketo-express#453. Opening as draft for now until the following are complete (unless we determine not to do the remaining work):

- [x] Use the [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) API rather than regex to determine time structure.
- [x] Use a locale-specific date string to determine whether a time *string* has a meridian component. This is necessary because you can't `new Date('01:00 pm')`.
- [x] Detect locale changes and updates the locale state used for the above accordingly.
- [x] Detect locale change to update widget state.
- ~~[ ] Format widget display state with locale-specific punctuation rather than hard coding the separator as `:`~~