### PR TITLE
Fix: use simpler selector for geopicker widgets

### DIFF
--- a/src/widget/geo/geopicker.js
+++ b/src/widget/geo/geopicker.js
@@ -77,7 +77,7 @@ class Geopicker extends Widget {
      * @type {string}
      */
     static get selector() {
-        return ':is(.question input[data-type-xml="geopoint"], .question input[data-type-xml="geotrace"], .question input[data-type-xml="geoshape"]):not([data-setvalue], [data-setgeopoint])';
+        return '.question input[data-type-xml="geopoint"]:not([data-setvalue], [data-setgeopoint]), .question input[data-type-xml="geotrace"]:not([data-setvalue], [data-setgeopoint]), .question input[data-type-xml="geoshape"]:not([data-setvalue], [data-setgeopoint])';
     }
 
     /**


### PR DESCRIPTION
Fixes #920.

I considered using the static method `condition` for the `:not` case, which may have better performance characteristics, but that would split the logic more than it already is. I think it might be better still to rethink how widgets are identified and initialized in general.