### PR TITLE
Fix/drawing widget blur 924

### DIFF
--- a/src/widget/draw/draw-widget.js
+++ b/src/widget/draw/draw-widget.js
@@ -135,15 +135,19 @@ class DrawWidget extends Widget {
             this._handleFiles(existingFilename);
         }
 
-        // We built a delay in saving on stroke "end", to avoid excessive updating
-        // This event does not fire on touchscreens for which we use the .hide-canvas-btn click
-        // to do the same thing.
+        // This listener (I think) serves to capture a drawing when the submit button is clicked within [DELAY]
+        // milliseconds after the last stroke ended. Note that this could be the entire drawing/signature.
         canvas.addEventListener('blur', () => {
             // If the canvas is empty, calling blur would result in an empty image file being created.
+            // Validation logic and traversing the form by keyboard could trigger those blur events on empty canvases.
             if (this.pad && !this.pad.isEmpty()) {
                 this._forceUpdate();
             }
         });
+
+        // We built a delay in saving on stroke "end", to avoid excessive updating
+        // This event does not fire on touchscreens for which we use the .hide-canvas-btn click
+        // to do the same thing.
 
         this.initialize = fileManager.init().then(() => {
             that.pad = new SignaturePad(canvas, {

--- a/src/widget/draw/draw-widget.js
+++ b/src/widget/draw/draw-widget.js
@@ -489,7 +489,7 @@ class DrawWidget extends Widget {
                     $(that.element).val('').trigger('change');
                     if (that._updateWithDelay) {
                         // This ensures that an emptied canvas will not be considered a drawing to be captured
-                        // in _forceUpdate, e.g. after the blur even fires on an empty canvas see issue #924
+                        // in _forceUpdate, e.g. after the blur event fires on an empty canvas see issue #924
                         that._updateWithDelay = null;
                     }
                     // Annotate file input

--- a/src/widget/draw/draw-widget.js
+++ b/src/widget/draw/draw-widget.js
@@ -137,9 +137,7 @@ class DrawWidget extends Widget {
 
         // This listener serves to capture a drawing when the submit button is clicked within [DELAY]
         // milliseconds after the last stroke ended. Note that this could be the entire drawing/signature.
-        canvas.addEventListener('blur', () => {
-            this._forceUpdate();
-        });
+        canvas.addEventListener('blur', this._forceUpdate.bind(this));
 
         // We built a delay in saving on stroke "end", to avoid excessive updating
         // This event does not fire on touchscreens for which we use the .hide-canvas-btn click

--- a/src/widget/draw/draw-widget.js
+++ b/src/widget/draw/draw-widget.js
@@ -138,7 +138,12 @@ class DrawWidget extends Widget {
         // We built a delay in saving on stroke "end", to avoid excessive updating
         // This event does not fire on touchscreens for which we use the .hide-canvas-btn click
         // to do the same thing.
-        canvas.addEventListener('blur', this._forceUpdate.bind(this));
+        canvas.addEventListener('blur', () => {
+            // If the canvas is empty, calling blur would result in an empty image file being created.
+            if (this.pad && !this.pad.isEmpty()) {
+                this._forceUpdate();
+            }
+        });
 
         this.initialize = fileManager.init().then(() => {
             that.pad = new SignaturePad(canvas, {
@@ -463,7 +468,7 @@ class DrawWidget extends Widget {
         const that = this;
 
         if (this.element.value) {
-            // This discombulated line is to help the i18next parser pick up all 3 keys.
+            // This discombobulated line is to help the i18next parser pick up all 3 keys.
             const item =
                 this.props.type === 'signature'
                     ? t('drawwidget.signature')

--- a/src/widget/draw/draw-widget.js
+++ b/src/widget/draw/draw-widget.js
@@ -135,14 +135,10 @@ class DrawWidget extends Widget {
             this._handleFiles(existingFilename);
         }
 
-        // This listener (I think) serves to capture a drawing when the submit button is clicked within [DELAY]
+        // This listener serves to capture a drawing when the submit button is clicked within [DELAY]
         // milliseconds after the last stroke ended. Note that this could be the entire drawing/signature.
         canvas.addEventListener('blur', () => {
-            // If the canvas is empty, calling blur would result in an empty image file being created.
-            // Validation logic and traversing the form by keyboard could trigger those blur events on empty canvases.
-            if (this.pad && !this.pad.isEmpty()) {
-                this._forceUpdate();
-            }
+            this._forceUpdate();
         });
 
         // We built a delay in saving on stroke "end", to avoid excessive updating
@@ -493,6 +489,11 @@ class DrawWidget extends Widget {
                     delete that.element.dataset.loadedUrl;
                     that.element.dataset.filenamePostfix = '';
                     $(that.element).val('').trigger('change');
+                    if (that._updateWithDelay) {
+                        // This ensures that an emptied canvas will not be considered a drawing to be captured
+                        // in _forceUpdate, e.g. after the blur even fires on an empty canvas see issue #924
+                        that._updateWithDelay = null;
+                    }
                     // Annotate file input
                     that.$widget
                         .find('input[type=file]')


### PR DESCRIPTION
closes issue #924 

I wasn't able to create a test for this. I'm guessing this is because canvas doesn't work in a headless browser. Fwiw, I tried this to get to the first step (just before resetting):

```js
describe('draw widget', () => {
    /** @type {import('sinon').SinonSandbox} */
    let sandbox;

    /** @type {SinonFakeTimers} */
    let timers;

    beforeEach(() => {
        sandbox = sinon.createSandbox();
        timers = sandbox.useFakeTimers();
    });

    afterEach(() => {
        timers.runAll();
        timers.clearTimeout();
        timers.clearInterval();
        timers.restore();
        sandbox.restore();
    });

    it(`does not create an image of an empty canvas when the canvas looses focus (blurs)
     after it has been reset at least once`, () => {
        const form = FORM2;
        const fragment = document.createRange().createContextualFragment(form);
        const control = fragment.querySelector(DrawWidget.selector);
        new DrawWidget(control);
        const canvas = fragment.querySelector('canvas');

        const touch1 = new Touch({
            identifier: 123,
            target: canvas,
        });

        const touchEvent1 = new TouchEvent('touchstart', {
            touches: [touch1],
        });

        const touch2 = new Touch({
            identifier: 234,
            target: canvas,
        });

        const touchEvent2 = new TouchEvent('touchend', {
            touches: [touch2],
        });

        canvas.dispatchEvent(touchEvent1);
        canvas.dispatchEvent(touchEvent2);
        canvas.dispatchEvent(new Event('blur'));

        expect(control.value).to.equal('signature.png');
    });
});
```

The fix is straightforward though, so maybe this is acceptable without a test? :shipit: 

I also considered, as an alternative fix, to get rid of the blur handler which would mean removing or much reducing the on-stroke-end delay in saving an image. However, it was considered out of scope to investigate whether this would cause (performance) issues on low-end devices.