### PR TITLE
Fix: undesired autocompletion of manually entered incomplete month-ye…

### DIFF
--- a/src/widget/date/datepicker-extended.js
+++ b/src/widget/date/datepicker-extended.js
@@ -92,12 +92,12 @@ class DatepickerExtended extends Widget {
             let value =
                 e.type === 'paste'
                     ? getPasteData(e.originalEvent ?? e)
-                    : this.value;
+                    : this.displayedValue;
 
             if (value.length > 0) {
                 // Note: types.date.convert considers numbers to be a number of days since the epoch
                 // as this is what the XPath evaluator may return.
-                // For user-entered input, we want to consider a Number value to be incorrect, expect for year input.
+                // For user-entered input, we want to consider a Number value to be incorrect, except for year input.
                 if (isNumber(value) && settings.format !== 'yyyy') {
                     convertedValue = '';
                 } else {

--- a/test/spec/widget.date.spec.js
+++ b/test/spec/widget.date.spec.js
@@ -98,6 +98,17 @@ describe('datepicker widget', () => {
 
                 expect(input.value).to.equal('');
             });
+            it(`sets empty string when user enters year and appearance is ${desc}`, () => {
+                const input = initForm(form).element;
+                const fakeInput = input
+                    .closest('.question')
+                    .querySelector('.widget input');
+
+                fakeInput.value = '2012';
+                fakeInput.dispatchEvent(new Event('change'));
+
+                expect(input.value).to.equal('');
+            });
         });
     });
 });


### PR DESCRIPTION
…ar dates, closes #943

I think this change is safe as it makes sense to perform the basic formatting check before manipulating the date value (by calling the `value` getter).