### PR TITLE
Fix: rank widget on touch devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2223,6 +2223,11 @@
                 "void-elements": "^2.0.0"
             }
         },
+        "drag-drop-touch": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/drag-drop-touch/-/drag-drop-touch-1.3.1.tgz",
+            "integrity": "sha512-Q0/ZgsnW7VUjn+YqSnp1rvxjjPnZX5YLyVaw28einood+eTMcLzgOgHk8nyqIF9O18J68l+2htlEnbw5GsyTvQ=="
+        },
         "duplexify": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     },
     "dependencies": {
         "bootstrap-datepicker": "1.9.x",
+        "drag-drop-touch": "^1.3.1",
         "html5sortable": "^0.13.3",
         "jquery": "^3.6.2",
         "jquery-touchswipe": "^1.6.19",

--- a/src/widget/rank/rank-widget.js
+++ b/src/widget/rank/rank-widget.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import 'drag-drop-touch';
 import sortable from 'html5sortable/dist/html5sortable.cjs';
 import { t } from 'enketo/translator';
 import Widget from '../../js/widget';
@@ -64,9 +65,19 @@ class RankWidget extends Widget {
 
         this.value = loadedValue;
 
+        this.list.querySelectorAll(this.itemSelector).forEach((item) => {
+            const handle = document.createElement('span');
+
+            handle.textContent = '::';
+            handle.className = 'handle';
+
+            item.append(handle);
+        });
+
         // Create the sortable drag-and-drop functionality
         sortable(this.list, {
             items: this.itemSelector,
+            handle: '.handle',
             // hoverClass: 'rank-widget__item--hover',
             containerSerializer(container) {
                 return {

--- a/src/widget/rank/rank-widget.scss
+++ b/src/widget/rank/rank-widget.scss
@@ -40,14 +40,27 @@
         border-radius: 5px;
         margin: 0 0 5px 0;
         position: relative;
-        &[draggable='true']::before {
-            position: absolute;
-            content: '::';
-            margin: 0 5px;
-            top: calc(50% - 10px);
+
+        .handle {
+            display: none;
+
+            &[draggable='true'] {
+                display: block;
+                position: absolute;
+                box-sizing: border-box;
+                padding: inherit;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                width: 2em;
+                text-indent: 5px;
+            }
         }
-        &:hover:not(.filler) {
-            background: none;
+
+        @media (pointer: fine) and (hover: 'hover') {
+            .handle[draggable='true'] {
+                width: 100%;
+            }
         }
     } //&__item--hover {}
     input[type='text'] {
@@ -56,5 +69,9 @@
     .btn-reset {
         margin-top: 5px;
         order: 10;
+    }
+
+    .question.simple-select &.option-wrapper > label:hover:not(.filler) {
+        background: none;
     }
 }


### PR DESCRIPTION
Fixes enketo/enketo-express#511

Verified on Moto G5 Chrome 109.0.5414.117

Not strictly necessary, but I also restricted touch dragging to the visible handle area (with some padding). I did this because testing on my own phone (iPhone, which turned out to reproduce the bug as well), I found it quite difficult to scroll anywhere near a rank question, and there's already a visible appearance of a handle on the side. Along with this change, I removed the "hover" effect on the full width rank options, because it no longer corresponds to the actionable area and could be confusing.

Happy to discuss those changes or make them separate, but I do think it would be a worse UX.