### PR TITLE
Fix: further simplify geopicker widget selector

### DIFF
--- a/src/widget/geo/geopicker.js
+++ b/src/widget/geo/geopicker.js
@@ -77,7 +77,7 @@ class Geopicker extends Widget {
      * @type {string}
      */
     static get selector() {
-        return '.question input[data-type-xml="geopoint"]:not([data-setvalue], [data-setgeopoint]), .question input[data-type-xml="geotrace"]:not([data-setvalue], [data-setgeopoint]), .question input[data-type-xml="geoshape"]:not([data-setvalue], [data-setgeopoint])';
+        return '.question input[data-type-xml="geopoint"]:not([data-setvalue]):not([data-setgeopoint]), .question input[data-type-xml="geotrace"]:not([data-setvalue]):not([data-setgeopoint]), .question input[data-type-xml="geoshape"]:not([data-setvalue]):not([data-setgeopoint])';
     }
 
     /**


### PR DESCRIPTION
Fixes #953. This is much narrower than the solution discussed there (detecting unused widgets on load so they don't continually query). It's probably worth doing as a separate change, but feels like overkill for this fix and probably best to evaluate its risk separately.