### PR TITLE
fixed: undesired newlines in print view in select/select1 labels, clo…

### DIFF
--- a/src/sass/core/_print.scss
+++ b/src/sass/core/_print.scss
@@ -147,7 +147,7 @@ input[type='checkbox'] {
             padding: 0;
         }
 
-        span:not(.or-output) {
+        > span:not(.or-output) {
             display: block;
         }
     }


### PR DESCRIPTION
…ses #956

As-minimal-as-possible change to avoid any display issues. I think the risk of regressions is very small (and only in print views).

I also checked if this worked in:

- the print view of the Formhub theme
- the print view of the Grid theme
- the interaction with a hint in both themes

<img width="748" alt="Screenshot 2023-03-01 at 2 01 40 PM" src="https://user-images.githubusercontent.com/627350/222238672-86a4c639-b2aa-47d3-88fd-5edcd1d98779.png">

