### PR TITLE
Fix: revert jQuery upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.2.1] - 2023-03-21
+
+-   Fix: revert jQuery upgrade to address regressions accessing jQuery extensions in Enketo Express (#964)
+
 ## [7.2.0] - 2023-03-20
 
 -   Reimplement draw/signature/annotate widget to preserve original image size when annotating and improve resize performance (#960)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "enketo-core",
-    "version": "7.2.0",
+    "version": "7.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -6496,9 +6496,9 @@
             }
         },
         "jquery": {
-            "version": "3.6.4",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.4.tgz",
-            "integrity": "sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ=="
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+            "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
         },
         "jquery-touchswipe": {
             "version": "1.6.19",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "enketo-core",
     "description": "Extensible Enketo form engine",
     "homepage": "https://enketo.org",
-    "version": "7.2.0",
+    "version": "7.2.1",
     "license": "Apache-2.0",
     "os": [
         "darwin",
@@ -106,7 +106,7 @@
         "bootstrap-datepicker": "1.9.x",
         "drag-drop-touch": "^1.3.1",
         "html5sortable": "^0.13.3",
-        "jquery": "^3.6.4",
+        "jquery": "3.6.3",
         "jquery-touchswipe": "^1.6.19",
         "leaflet": "^1.9.3",
         "leaflet-draw": "github:enketo/Leaflet.draw#ff73078",


### PR DESCRIPTION
This change introduced regressions causing `TypeError`s when accessing jQuery extensions in Enketo Express