### PR TITLE
Fix: focus first active input/widget on load, page navigation, user-added repeat

### DIFF
--- a/src/js/dom-utils.js
+++ b/src/js/dom-utils.js
@@ -463,6 +463,34 @@ class MutationsTracker {
     }
 }
 
+/** @type {HTMLElement | null} */
+let scrollIntoViewTarget = null;
+
+const intersectionObserver = new IntersectionObserver((records) => {
+    for (const { target, isIntersecting } of records) {
+        if (target === scrollIntoViewTarget && !isIntersecting) {
+            target.scrollIntoView({
+                block: 'nearest',
+                inline: 'nearest',
+            });
+        }
+
+        intersectionObserver.unobserve(target);
+    }
+});
+
+/**
+ * Roughly equivalent to the non-standard
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoViewIfNeeded | Element.scrollIntoViewIfNeeded},
+ * but scrolls to the nearest edges of the viewport.
+ *
+ * @param {HTMLElement} element
+ */
+const scrollIntoViewIfNeeded = (element) => {
+    scrollIntoViewTarget = element;
+    intersectionObserver.observe(element);
+};
+
 export {
     /**
      * @static
@@ -484,4 +512,5 @@ export {
     closestAncestorUntil,
     empty,
     MutationsTracker,
+    scrollIntoViewIfNeeded,
 };

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -1475,14 +1475,18 @@ Form.prototype.goToTarget = function (target, options = {}) {
         }
         // Scroll to element
         target.scrollIntoView();
-        // Focus on the first non .ignore form control
+
+        // Focus on the first non .ignore form control which is not currently readonly.
         // If the element is hidden (e.g. because it's been replaced by a widget),
         // the focus event will not fire, so we also trigger an applyfocus event that widgets can listen for.
         const input = target.querySelector(
             'input:not(.ignore):not([readonly]), textarea:not(.ignore):not([readonly]), select:not(.ignore):not([readonly])'
         );
-        input.focus();
-        input.dispatchEvent(events.ApplyFocus());
+
+        if (input != null) {
+            input.focus();
+            input.dispatchEvent(events.ApplyFocus());
+        }
     }
 
     return !!target;

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -13,6 +13,7 @@ import {
     getChild,
     closestAncestorUntil,
     getSiblingElement,
+    scrollIntoViewIfNeeded,
 } from './dom-utils';
 import { initTimeLocalization } from './format';
 import inputHelper from './input';
@@ -488,7 +489,7 @@ Form.prototype.init = function () {
         loadErrors.push(`${e.name}: ${e.message}`);
     }
 
-    document.querySelector('body').scrollIntoView();
+    document.body.scrollIntoView();
 
     return loadErrors;
 };
@@ -1473,8 +1474,6 @@ Form.prototype.goToTarget = function (target, options = {}) {
             // It is up to the apps to decide what to do with this event.
             target.dispatchEvent(events.GoToIrrelevant());
         }
-        // Scroll to element
-        target.scrollIntoView();
 
         // Focus on the first non .ignore form control which is not currently readonly.
         // If the element is hidden (e.g. because it's been replaced by a widget),
@@ -1487,6 +1486,10 @@ Form.prototype.goToTarget = function (target, options = {}) {
             input.focus();
             input.dispatchEvent(events.ApplyFocus());
         }
+
+        // Scroll to element if needed. This will generally be a noop unless no
+        // focusable control was found (e.g. readonly question in pages mode).
+        scrollIntoViewIfNeeded(target);
     }
 
     return !!target;

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -474,6 +474,8 @@ Form.prototype.init = function () {
             this.view.$.addClass('print-relevant-only');
         }
 
+        this.goToTarget(this.view.html);
+
         setTimeout(() => {
             that.progress.update();
         }, 0);
@@ -1444,14 +1446,20 @@ Form.prototype.getGoToTarget = function (path) {
 };
 
 /**
+ * @typedef GoToTargetOptions
+ * @property {boolean} [isPageFlip]
+ */
+
+/**
  * Scrolls to an HTML question or group element, flips to the page it is on and focuses on the nearest form control.
  *
  * @param {HTMLElement} target - An HTML question or group element to scroll to
+ * @param {GoToTargetOptions} [options]
  * @return {boolean} whether target found
  */
-Form.prototype.goToTarget = function (target) {
+Form.prototype.goToTarget = function (target, options = {}) {
     if (target) {
-        if (this.pages.active) {
+        if (this.pages.active && !options.isPageFlip) {
             // Flip to page
             this.pages.flipToPageContaining($(target));
         }
@@ -1471,7 +1479,7 @@ Form.prototype.goToTarget = function (target) {
         // If the element is hidden (e.g. because it's been replaced by a widget),
         // the focus event will not fire, so we also trigger an applyfocus event that widgets can listen for.
         const input = target.querySelector(
-            'input:not(.ignore), textarea:not(.ignore), select:not(.ignore)'
+            'input:not(.ignore):not([readonly]), textarea:not(.ignore):not([readonly]), select:not(.ignore):not([readonly])'
         );
         input.focus();
         input.dispatchEvent(events.ApplyFocus());

--- a/src/js/page.js
+++ b/src/js/page.js
@@ -219,7 +219,7 @@ export default {
                         );
                         if (destItem && destItem.element) {
                             const destEl = destItem.element;
-                            that.form.goToTarget(destEl);
+                            that.form.goToTarget(destEl, { isPageFlip: true });
                         }
                     }
                 }
@@ -407,7 +407,7 @@ export default {
             '.or'
         ).forEach((el) => el.classList.add('contains-current'));
         this.current = pageEl;
-        this.form.goToTarget(pageEl);
+        this.form.goToTarget(pageEl, { isPageFlip: true });
     },
     /**
      * Switches to a page

--- a/src/js/page.js
+++ b/src/js/page.js
@@ -407,6 +407,7 @@ export default {
             '.or'
         ).forEach((el) => el.classList.add('contains-current'));
         this.current = pageEl;
+        this.form.goToTarget(pageEl);
     },
     /**
      * Switches to a page
@@ -430,12 +431,14 @@ export default {
                 this._focusOnFirstQuestion(pageEl);
                 this._toggleButtons(newIndex);
                 pageEl.dispatchEvent(events.PageFlip());
+                this.form.goToTarget(pageEl, { isPageFlip: true });
             }
         } else if (pageEl) {
             this._setToCurrent(pageEl);
             this._focusOnFirstQuestion(pageEl);
             this._toggleButtons(newIndex);
             pageEl.dispatchEvent(events.PageFlip());
+            this.form.goToTarget(pageEl, { isPageFlip: true });
             pageEl.setAttribute('tabindex', 1);
         }
     },

--- a/src/js/repeat.js
+++ b/src/js/repeat.js
@@ -443,6 +443,10 @@ export default {
             // Initialize widgets in clone after default values have been set
             if (this.form.widgetsInitialized) {
                 this.form.widgets.init($(clone), this.form.options);
+
+                if (trigger === 'user' && i === 0) {
+                    this.form.goToTarget(clone);
+                }
             }
             // now create the first instance of any nested repeats if necessary
             clone

--- a/test/forms/focus.xml
+++ b/test/forms/focus.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+    xmlns:enk="http://enketo.org/xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:oc="http://openclinica.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>Focus</h:title>
+        <model>
+            <instance>
+                <data>
+                    <field-page />
+                    <select-page />
+                    <group-page>
+                        <group-readonly-empty-field />
+                        <group-readonly-calc-field />
+                        <group-field />
+                        <group-field2 />
+                    </group-page>
+                    <repeats-page>
+                        <repeats-readonly-empty-field />
+                        <repeats-readonly-calc-field />
+                        <repeats-field />
+                        <repeats-field2 />
+                    </repeats-page>
+                    <repeat-page>
+                        <repeat-readonly-empty-field />
+                        <repeat-readonly-calc-field />
+                        <repeat-field />
+                        <repeat-field2 />
+                    </repeat-page>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+
+            <bind nodeset="/data/field-page" />
+            <bind nodeset="/data/select-page" />
+
+            <bind nodeset="/data/group-page/group-readonly-empty-field" readonly="true()" />
+            <bind nodeset="/data/group-page/group-readonly-calc-field" readonly="true()" calculate="'calculated'" />
+            <bind nodeset="/data/group-page/group-field" />
+            <bind nodeset="/data/group-page/group-field2" />
+
+            <bind nodeset="/data/repeats-page/repeats-readonly-empty-field" readonly="true()" />
+            <bind nodeset="/data/repeats-page/repeats-readonly-calc-field" readonly="true()" calculate="'calculated'" />
+            <bind nodeset="/data/repeats-page/repeats-field" />
+            <bind nodeset="/data/repeats-page/repeats-field2" />
+
+            <bind nodeset="/data/repeat-page/repeat-readonly-empty-field" readonly="true()" />
+            <bind nodeset="/data/repeat-page/repeat-readonly-calc-field" readonly="true()" calculate="'calculated'" />
+            <bind nodeset="/data/repeat-page/repeat-field" />
+            <bind nodeset="/data/repeat-page/repeat-field2" />
+
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body class="pages">
+        <input ref="/data/field-page">
+            <label>Field page</label>
+        </input>
+
+        <select ref="/data/select-page" appearance="w6 minimal">
+            <label>Select page</label>
+            <item>
+                <value>1</value>
+                <label>One</label>
+            </item>
+        </select>
+
+        <group ref="/data/group-page" appearance="field-list">
+            <label>Group page</label>
+
+            <input ref="/data/group-page/group-readonly-empty-field">
+                <label>Readonly (empty = hidden) field</label>
+            </input>
+            <input ref="/data/group-page/group-readonly-calc-field">
+                <label>Readonly (calculated) field</label>
+            </input>
+
+            <select ref="/data/group-page/group-field" appearance="w6 minimal">
+                <label>Group field</label>
+                <item>
+                    <value>1</value>
+                    <label>One</label>
+                </item>
+            </select>
+
+            <select ref="/data/group-page/group-field2" appearance="w6 minimal">
+                <label>Group field 2</label>
+                <item>
+                    <value>1</value>
+                    <label>One</label>
+                </item>
+            </select>
+        </group>
+
+        <group ref="/data/repeats-page" appearance="field-list">
+            <label>Repeats (grouped in field-list) page</label>
+
+            <repeat nodeset="/data/repeats-page">
+                <input ref="/data/repeats-page/repeats-readonly-empty-field">
+                    <label>Readonly (empty = hidden) field</label>
+                </input>
+                <input ref="/data/repeats-page/repeats-readonly-calc-field">
+                    <label>Readonly (calculated) field</label>
+                </input>
+
+                <select ref="/data/repeats-page/repeats-field" appearance="w6 minimal">
+                    <label>Repeats field</label>
+                    <item>
+                        <value>1</value>
+                        <label>One</label>
+                    </item>
+                </select>
+
+                <select ref="/data/repeats-page/repeats-field2" appearance="w6 minimal">
+                    <label>Repeats field 2</label>
+                    <item>
+                        <value>1</value>
+                        <label>One</label>
+                    </item>
+                </select>
+            </repeat>
+        </group>
+
+        <group ref="/data/repeat-page">
+            <label>Repeat (self field-list) page</label>
+
+            <repeat nodeset="/data/repeat-page" appearance="field-list">
+                <input ref="/data/repeat-page/repeat-readonly-empty-field">
+                    <label>Readonly (empty = hidden) field</label>
+                </input>
+                <input ref="/data/repeat-page/repeat-readonly-calc-field">
+                    <label>Readonly (calculated) field</label>
+                </input>
+
+                <select ref="/data/repeat-page/repeat-field" appearance="w6 minimal">
+                    <label>Repeat field</label>
+                    <item>
+                        <value>1</value>
+                        <label>One</label>
+                    </item>
+                </select>
+
+                <select ref="/data/repeat-page/repeat-field2" appearance="w6 minimal">
+                    <label>Repeat field 2</label>
+                    <item>
+                        <value>1</value>
+                        <label>One</label>
+                    </item>
+                </select>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>

--- a/test/forms/focus.xml
+++ b/test/forms/focus.xml
@@ -13,6 +13,7 @@
             <instance>
                 <data>
                     <field-page />
+                    <relevant-page />
                     <select-page />
                     <group-page>
                         <group-readonly-empty-field />
@@ -39,6 +40,7 @@
             </instance>
 
             <bind nodeset="/data/field-page" />
+            <bind nodeset="/data/relevant-page" relevant="/data/field-page = '1'" />
             <bind nodeset="/data/select-page" />
 
             <bind nodeset="/data/group-page/group-readonly-empty-field" readonly="true()" />
@@ -62,6 +64,10 @@
     <h:body class="pages">
         <input ref="/data/field-page">
             <label>Field page</label>
+        </input>
+
+        <input ref="/data/relevant-page">
+            <label>Relevant page</label>
         </input>
 
         <select ref="/data/select-page" appearance="w6 minimal">

--- a/test/spec/form.spec.js
+++ b/test/spec/form.spec.js
@@ -2091,6 +2091,23 @@ describe('Focus', () => {
                 expect(document.activeElement).to.equal(selectButton);
             });
 
+            it('focuses a newly relevant field when advancing to its page', () => {
+                const firstInput = formElement.querySelector(
+                    'input[name="/data/field-page"]'
+                );
+
+                firstInput.value = '1';
+                $(firstInput).trigger('change');
+
+                const relevantInput = formElement.querySelector(
+                    'input[name="/data/relevant-page"]'
+                );
+
+                callback(relevantInput);
+
+                expect(document.activeElement).to.equal(relevantInput);
+            });
+
             it('focuses a select field toggle button within a group after readonly fields', () => {
                 const selectButton = getSelectButton(
                     '/data/group-page/group-field'

--- a/test/spec/form.spec.js
+++ b/test/spec/form.spec.js
@@ -1999,6 +1999,170 @@ describe('Adding tasks to the default evaluation cascade', () => {
     });
 });
 
+describe('Focus', () => {
+    /** @type {Form)} */
+    let form;
+
+    /** @type {HTMLFormElement} */
+    let formElement;
+
+    /** @type {HTMLElement} */
+    let nextPageButton;
+
+    /**
+     * @param {string} fieldName
+     * @param {number} index
+     */
+    const getSelectButton = (fieldName, index = 0) => {
+        const input = formElement.querySelectorAll(`*[name="${fieldName}"]`)[
+            index
+        ];
+
+        return input.closest('.question').querySelector('.btn.dropdown-toggle');
+    };
+
+    beforeEach(() => {
+        const formFooter = document.createElement('section');
+
+        form = loadForm('focus.xml');
+        formElement = form.view.html;
+        formFooter.classList.add('form-footer');
+        document.body.append(formElement, formFooter);
+        nextPageButton = document.createElement('a');
+        nextPageButton.href = '#';
+        nextPageButton.type = 'button';
+        nextPageButton.classList.add(
+            'btn',
+            'btn-primary',
+            'next-page',
+            'disabled'
+        );
+        formFooter.append(nextPageButton);
+
+        const loadErrors = form.init();
+
+        expect(loadErrors).to.deep.equal(
+            [],
+            JSON.stringify(loadErrors, null, 2)
+        );
+    });
+
+    afterEach(() => {
+        form.resetView();
+        formElement?.remove();
+    });
+
+    it('focuses the first field on load', () => {
+        const input = formElement.querySelector(
+            'input[name="/data/field-page"]'
+        );
+
+        expect(document.activeElement).to.equal(input);
+    });
+
+    const navigations = [
+        {
+            navigationMethod: 'pages.flipToPageContaining',
+            callback:
+                /** @param {HTMLElement} element */
+                (element) => form.pages.flipToPageContaining($(element)),
+        },
+        {
+            navigationMethod: 'form.goToTarget',
+            callback:
+                /** @param {HTMLElement} element */
+                (element) =>
+                    form.goToTarget(
+                        element.closest('.repeat') ??
+                            element.closest('.group') ??
+                            element.closest('.question')
+                    ),
+        },
+    ];
+
+    navigations.forEach(({ navigationMethod, callback }) => {
+        describe(`with navigation method ${navigationMethod}`, () => {
+            it('focuses a select field toggle button when advancing to its page', () => {
+                const selectButton = getSelectButton('/data/select-page');
+                const selectQuestion = selectButton.closest('.question');
+
+                callback(selectQuestion);
+
+                expect(document.activeElement).to.equal(selectButton);
+            });
+
+            it('focuses a select field toggle button within a group after readonly fields', () => {
+                const selectButton = getSelectButton(
+                    '/data/group-page/group-field'
+                );
+                const selectQuestion = selectButton.closest('.question');
+
+                callback(selectQuestion);
+
+                expect(document.activeElement).to.equal(selectButton);
+            });
+
+            it("focuses a select field toggle button within a grouped field-list's repeat after readonly fields", () => {
+                const selectButton = getSelectButton(
+                    '/data/repeats-page/repeats-field'
+                );
+                const selectQuestion = selectButton.closest('.question');
+
+                callback(selectQuestion);
+
+                expect(document.activeElement).to.equal(selectButton);
+            });
+
+            it("focuses a select field toggle button within a grouped field-list's repeat clone after readonly fields", () => {
+                const addRepeatButton = formElement.querySelector(
+                    '.or-repeat-info[data-name="/data/repeats-page"] .add-repeat-btn'
+                );
+
+                addRepeatButton.click();
+
+                const selectButton = getSelectButton(
+                    '/data/repeats-page/repeats-field',
+                    1
+                );
+                const selectQuestion = selectButton.closest('.question');
+
+                callback(selectQuestion);
+
+                expect(document.activeElement).to.equal(selectButton);
+            });
+
+            it('focuses a select field toggle button within a repeat instance field-list after readonly fields', () => {
+                const selectButton = getSelectButton(
+                    '/data/repeat-page/repeat-field'
+                );
+                const selectQuestion = selectButton.closest('.question');
+
+                callback(selectQuestion);
+
+                expect(document.activeElement).to.equal(selectButton);
+            });
+
+            it('focuses a select field toggle button within a repeat instance field-list clone after readonly fields', () => {
+                const addRepeatButton = formElement.querySelector(
+                    '.or-repeat-info[data-name="/data/repeat-page"] .add-repeat-btn'
+                );
+
+                addRepeatButton.click();
+
+                const selectButton = getSelectButton(
+                    '/data/repeat-page/repeat-field',
+                    1
+                );
+                const selectQuestion = selectButton.closest('.question');
+
+                callback(selectQuestion);
+
+                expect(document.activeElement).to.equal(selectButton);
+            });
+        });
+    });
+});
+
 function mockChoiceNameForm() {
     const val = '__MOCK_MODEL_VALUE__';
 


### PR DESCRIPTION
Fixes enketo/enketo-express#277. The tests aren't exhaustive e.g no tests for non-user-added repeats, how relevance impacts determination of whether a field is active. I'd be happy to add any test scenarios but wanted to get this into review first. It's also probably not an exhaustive fix. I hadn't originally caught the select toggle button case, nor the readonly cases (which is why they're used so much in the tests), and I would be surprised if there aren't other edge cases I haven't encountered.