### PR TITLE
Performance improvements: NumberInput widgets, `excludeNonRelevant`

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -532,6 +532,8 @@ Form.prototype.getDataStr = function (include = {}) {
  * @return {Element} the new form element
  */
 Form.prototype.resetView = function () {
+    this.widgets.reset();
+
     // form language selector was moved outside of <form> so has to be separately removed
     if (this.langs.formLanguages) {
         this.langs.formLanguages.remove();

--- a/src/js/relevant.js
+++ b/src/js/relevant.js
@@ -422,11 +422,14 @@ export default {
             for (const node of modelNodes) {
                 const isLeafNode = node.children.length === 0;
                 const isReferencedNode = referencedModelNodes.has(node);
+                const { textContent } = node;
                 const currentValue = isLeafNode
-                    ? node.textContent ||
-                      (relevanceState.get(node)?.currentValue ??
-                          node.textContent)
+                    ? textContent ||
+                      (relevanceState.get(node)?.currentValue ?? textContent)
                     : null;
+                const isChanged = setRelevant
+                    ? textContent !== currentValue
+                    : textContent !== '';
                 const currentRelevanceState = relevanceState.get(node);
                 const isParentNonRelevant = Boolean(
                     currentRelevanceState?.isParentNonRelevant
@@ -438,6 +441,7 @@ export default {
                 if (setRelevant) {
                     if (
                         isLeafNode &&
+                        textContent !== currentValue &&
                         (isReferencedNode || !isSelfNonRelevant)
                     ) {
                         node.textContent = currentValue;
@@ -456,7 +460,7 @@ export default {
                             : currentValue,
                     });
                 } else {
-                    if (isLeafNode) {
+                    if (isLeafNode && textContent !== '') {
                         node.textContent = '';
                     }
 
@@ -472,7 +476,7 @@ export default {
                     });
                 }
 
-                if (isLeafNode) {
+                if (isLeafNode && isChanged) {
                     updatedElements.unshift(node);
                 }
             }
@@ -485,6 +489,8 @@ export default {
                     })
                 );
             }
+        } else {
+            this.toggleNonRelevantModelNodes = () => {};
         }
     },
 

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -17,6 +17,15 @@ class Widget {
         this.rootElement = rootElement;
     }
 
+    static globalReset() {
+        const { form, rootElement } = this;
+
+        delete this.form;
+        delete this.rootElement;
+
+        return { form, rootElement };
+    }
+
     /**
      * @class
      * @param {Element} element - The DOM element the widget is applied on

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -9,6 +9,15 @@ const range = document.createRange();
  */
 class Widget {
     /**
+     * @param {import('./form').Form} form
+     * @param {HTMLFormElement} rootElement
+     */
+    static globalInit(form, rootElement) {
+        this.form = form;
+        this.rootElement = rootElement;
+    }
+
+    /**
      * @class
      * @param {Element} element - The DOM element the widget is applied on
      * @param {(boolean|{touch: boolean})} [options] - Options passed to the widget during instantiation

--- a/src/js/widgets-controller.js
+++ b/src/js/widgets-controller.js
@@ -9,7 +9,12 @@ import events from './event';
 
 const widgets = _widgets.filter((widget) => widget.selector);
 let options;
-let formHtml;
+
+/** @type {import('./form').Form} */
+let form;
+
+/** @type {HTMLFormElement} */
+let formElement;
 
 /**
  * Initializes widgets
@@ -27,9 +32,10 @@ function init($group, opts = {}) {
     }
 
     options = opts;
-    formHtml = this.form.view.html; // not sure why this is only available in init
+    form = this.form;
+    formElement = this.form.view.html; // not sure why this is only available in init
 
-    const group = $group && $group.length ? $group[0] : formHtml;
+    const group = $group && $group.length ? $group[0] : formElement;
 
     widgets.forEach((Widget) => {
         _instantiate(Widget, group);
@@ -85,7 +91,7 @@ function disable(group) {
 function _getElements(group, selector) {
     if (selector) {
         if (selector === 'form') {
-            return [formHtml];
+            return [formElement];
         }
         // e.g. if the widget selector starts at .question level (e.g. ".or-appearance-draw input")
         if (group.classList.contains('question')) {
@@ -105,7 +111,7 @@ function _getElements(group, selector) {
 /**
  * Instantiate a widget on a group (whole form or newly cloned repeat)
  *
- * @param {object} Widget - The widget to instantiate
+ * @param {typeof import('./widget').default} Widget
  * @param {Element} group - The element inside which widgets need to be created.
  */
 function _instantiate(Widget, group) {
@@ -128,6 +134,8 @@ function _instantiate(Widget, group) {
         return;
     }
 
+    Widget.globalInit(form, formElement);
+
     new Collection(elements).instantiate(Widget, opts);
 
     _setLangChangeListener(Widget, elements);
@@ -146,7 +154,7 @@ function _instantiate(Widget, group) {
 function _setLangChangeListener(Widget, els) {
     // call update for all widgets when language changes
     if (els.length > 0) {
-        formHtml.addEventListener(events.ChangeLanguage().type, () => {
+        formElement.addEventListener(events.ChangeLanguage().type, () => {
             new Collection(els).update(Widget);
         });
     }

--- a/src/js/widgets-controller.js
+++ b/src/js/widgets-controller.js
@@ -134,7 +134,9 @@ function _instantiate(Widget, group) {
         return;
     }
 
-    Widget.globalInit(form, formElement);
+    if (group === formElement) {
+        Widget.globalInit(form, formElement);
+    }
 
     new Collection(elements).instantiate(Widget, opts);
 
@@ -142,6 +144,12 @@ function _instantiate(Widget, group) {
     _setOptionChangeListener(Widget, elements);
     _setValChangeListener(Widget, elements);
 }
+
+const reset = () => {
+    widgets.forEach((Widget) => {
+        Widget.globalReset();
+    });
+};
 
 /**
  * Calls widget('update') when the language changes. This function is called upon initialization,
@@ -276,4 +284,5 @@ export default {
     init,
     enable,
     disable,
+    reset,
 };

--- a/src/widget/number-input/decimal-input.js
+++ b/src/widget/number-input/decimal-input.js
@@ -1,7 +1,7 @@
 import NumberInput from './number-input';
 
 /** @type {Map<string, Set<string>>} */
-const decimalCharactersByLanguage = new Map();
+let decimalCharactersByLanguage = new Map();
 
 /**
  * @param {string[]} languages
@@ -28,7 +28,7 @@ const getDecimalCharacters = (languages) => {
 };
 
 /** @type {Map<string, RegExp>} */
-const characterPatternsByLanguage = new Map();
+let characterPatternsByLanguage = new Map();
 
 /**
  * @param {string[]} languages
@@ -52,7 +52,7 @@ const getCharacterPattern = (languages) => {
 };
 
 /** @type {Map<string, RegExp>} */
-const validityPatternsByLanguage = new Map();
+let validityPatternsByLanguage = new Map();
 
 /**
  * @param {string[]} languages
@@ -77,10 +77,6 @@ const getValidityPattern = (languages) => {
 };
 
 export default class DecimalInput extends NumberInput {
-    static languageChanged() {
-        return super.languageChanged.call(this);
-    }
-
     /**
      * @param {import('./form').Form} form
      * @param {HTMLFormElement} rootElement
@@ -88,6 +84,17 @@ export default class DecimalInput extends NumberInput {
     static globalInit(form, rootElement) {
         this.languageChanged = this.languageChanged.bind(this);
         super.globalInit(form, rootElement);
+    }
+
+    /**
+     * @param {import('./form').Form} form
+     * @param {HTMLFormElement} rootElement
+     */
+    static globalReset(form, rootElement) {
+        decimalCharactersByLanguage = new Map();
+        characterPatternsByLanguage = new Map();
+        validityPatternsByLanguage = new Map();
+        super.globalReset(form, rootElement);
     }
 
     static selector = '.question input[type="number"][data-type-xml="decimal"]';

--- a/src/widget/number-input/decimal-input.js
+++ b/src/widget/number-input/decimal-input.js
@@ -1,18 +1,172 @@
+import events from '../../js/event';
 import NumberInput from './number-input';
 
-export default class DecimalInput extends NumberInput {
-    static get numberType() {
-        return 'decimal';
+/** @type {Map<string, Set<string>>} */
+const decimalCharactersByLanguage = new Map();
+
+/**
+ * @param {string[]} languages
+ */
+const getDecimalCharacters = (languages) => {
+    const [language] = languages;
+
+    let characters = decimalCharactersByLanguage.get(language);
+
+    if (characters != null) {
+        return characters;
     }
 
-    get decimalCharacters() {
-        const locales = Intl.getCanonicalLocales(this.languages);
-        const formatter = Intl.NumberFormat(locales);
-        const decimal = formatter
-            .formatToParts(0.1)
-            .find(({ type }) => type === 'decimal').value;
+    const locales = Intl.getCanonicalLocales(languages);
+    const formatter = Intl.NumberFormat(locales);
+    const decimal = formatter
+        .formatToParts(0.1)
+        .find(({ type }) => type === 'decimal').value;
 
-        return new Set([...super.decimalCharacters, '.', decimal]);
+    characters = new Set(['.', decimal]);
+    decimalCharactersByLanguage.set(language, characters);
+
+    return characters;
+};
+
+/** @type {Map<string, RegExp>} */
+const characterPatternsByLanguage = new Map();
+
+/**
+ * @param {string[]} languages
+ */
+const getCharacterPattern = (languages) => {
+    const [language] = languages;
+    let characterPattern = characterPatternsByLanguage.get(language);
+
+    if (characterPattern != null) {
+        return characterPattern;
+    }
+
+    const decimalCharacters = getDecimalCharacters(language);
+
+    characterPattern = new RegExp(
+        `[-0-9${Array.from(decimalCharacters).join('')}]`
+    );
+    characterPatternsByLanguage.set(language, characterPattern);
+
+    return characterPattern;
+};
+
+/** @type {Map<string, RegExp>} */
+const validityPatternsByLanguage = new Map();
+
+/**
+ * @param {string[]} languages
+ */
+const getValidityPattern = (languages) => {
+    const [language] = languages;
+
+    let validityPattern = validityPatternsByLanguage.get(language);
+
+    if (validityPattern != null) {
+        return validityPattern;
+    }
+
+    const decimalCharacters = getDecimalCharacters(language);
+    const decimalPattern = `([${Array.from(decimalCharacters).join('')}]\\d+)?`;
+    const pattern = `^-?\\d+${decimalPattern}$`;
+
+    validityPattern = new RegExp(pattern);
+    validityPatternsByLanguage.set(language, validityPattern);
+
+    return validityPattern;
+};
+
+/** @type {Set<DecimalInput>} */
+const decimalInputs = new Set();
+
+export default class DecimalInput extends NumberInput {
+    static selector = '.question input[type="number"][data-type-xml="decimal"]';
+
+    static get decimalCharacters() {
+        return getDecimalCharacters(this.languages);
+    }
+
+    static get characterPattern() {
+        return getCharacterPattern(this.languages);
+    }
+
+    static get pattern() {
+        return getValidityPattern(this.languages);
+    }
+
+    /**
+     * @param {import('./form').Form} form
+     * @param {HTMLFormElement} rootElement
+     */
+    static globalInit(form, rootElement) {
+        super.globalInit(form, rootElement);
+
+        const languageChanged = () => {
+            const patternStr = this.pattern.source;
+
+            Array.from(decimalInputs.values()).forEach((decimalInput) => {
+                // Important: this value may become invalid if it isn't accessed
+                // before setting `lang`. This repros in Firefox if:
+                //
+                // 1. Your default language is English
+                // 2. Set a decimal value
+                // 3. Switch to French
+                // 4. Switch back to English
+                const { element, question } = decimalInput;
+                const { valueAsNumber } = element;
+
+                question.setAttribute('lang', this.language);
+                element.setAttribute('pattern', patternStr);
+                decimalInput.setFormattedValue(valueAsNumber);
+                decimalInput.setValidity();
+            });
+        };
+
+        rootElement.addEventListener(
+            events.ChangeLanguage().type,
+            languageChanged
+        );
+        window.addEventListener('languagechange', languageChanged);
+    }
+
+    /**
+     * @private
+     * @type {string[] | null}
+     */
+    _languages = null;
+
+    static get languages() {
+        let result = this._languages;
+
+        if (result != null) {
+            return result;
+        }
+
+        const { currentLanguage } = this.form;
+
+        let validFormLanguage;
+
+        try {
+            Intl.getCanonicalLocales(currentLanguage);
+
+            validFormLanguage = currentLanguage;
+        } catch {
+            // If this fails, the form's selected language is likely not a valid
+            // code and will cause all other `Intl` usage to fail.
+        }
+
+        result = [validFormLanguage, ...navigator.languages].filter(
+            (language) => language != null
+        );
+
+        this._languages = result;
+
+        return result;
+    }
+
+    static get language() {
+        return this.languages[0] ?? navigator.language;
     }
 
     get value() {
@@ -21,5 +175,13 @@ export default class DecimalInput extends NumberInput {
 
     set value(value) {
         super.value = value;
+    }
+
+    constructor(input, options) {
+        super(input, options);
+
+        decimalInputs.add(this);
+
+        this.question.setAttribute('lang', this.constructor.language);
     }
 }

--- a/src/widget/number-input/integer-input.js
+++ b/src/widget/number-input/integer-input.js
@@ -1,6 +1,19 @@
 import NumberInput from './number-input';
 
 export default class IntegerInput extends NumberInput {
+    static languageChanged() {
+        return super.languageChanged.call(this);
+    }
+
+    /**
+     * @param {import('./form').Form} form
+     * @param {HTMLFormElement} rootElement
+     */
+    static globalInit(form, rootElement) {
+        this.languageChanged = this.languageChanged.bind(this);
+        super.globalInit(form, rootElement);
+    }
+
     static selector = '.question input[type="number"][data-type-xml="int"]';
 
     static characterPattern = /[-0-9]/;
@@ -13,11 +26,5 @@ export default class IntegerInput extends NumberInput {
 
     set value(value) {
         super.value = value;
-    }
-
-    constructor(input, options) {
-        super(input, options);
-
-        input.setAttribute('pattern', this.constructor.pattern.source);
     }
 }

--- a/src/widget/number-input/integer-input.js
+++ b/src/widget/number-input/integer-input.js
@@ -1,9 +1,11 @@
 import NumberInput from './number-input';
 
 export default class IntegerInput extends NumberInput {
-    static get numberType() {
-        return 'int';
-    }
+    static selector = '.question input[type="number"][data-type-xml="int"]';
+
+    static characterPattern = /[-0-9]/;
+
+    static pattern = /^-?[0-9]+$/;
 
     get value() {
         return super.value;
@@ -11,5 +13,11 @@ export default class IntegerInput extends NumberInput {
 
     set value(value) {
         super.value = value;
+    }
+
+    constructor(input, options) {
+        super(input, options);
+
+        input.setAttribute('pattern', this.constructor.pattern.source);
     }
 }

--- a/src/widget/number-input/integer-input.js
+++ b/src/widget/number-input/integer-input.js
@@ -1,10 +1,6 @@
 import NumberInput from './number-input';
 
 export default class IntegerInput extends NumberInput {
-    static languageChanged() {
-        return super.languageChanged.call(this);
-    }
-
     /**
      * @param {import('./form').Form} form
      * @param {HTMLFormElement} rootElement

--- a/src/widget/number-input/number-input.js
+++ b/src/widget/number-input/number-input.js
@@ -3,10 +3,10 @@ import { t } from '../../js/fake-translator';
 import Widget from '../../js/widget';
 
 /** @type {Set<NumberInput>} */
-const numberInputInstances = new Set();
+let numberInputInstances = new Set();
 
 /** @type {WeakMap<HTMLInputElement, HTMLElement>} */
-const questionsByInput = new WeakMap();
+let questionsByInput = new WeakMap();
 
 /**
  * @param {HTMLInputElement} input
@@ -80,6 +80,8 @@ class NumberInput extends Widget {
         }
 
         this._languages = null;
+        numberInputInstances = new Set();
+        questionsByInput = new WeakMap();
     }
 
     /**


### PR DESCRIPTION
This change includes performance optimizations to perform fewer redundant operations in:

- `NumberInput` widgets (`DecimalInput`, `IntegerInput`). Their original implementation introduced a performance regression for forms with a large quantity of numeric inputs. Some of the pertinent change may benefit other widgets, i.e. they may be able to take advantage of `globalInit`, which is currently being used to cache the global form element rather than repeatedly querying for it, and to cache the localization behaviors in `DecimalInput`. Other changes move more decimal-specific logic from `NumberInput` to `DecimalInput` so that logic isn't performed needlessly by `IntegerInput`.

- Relevance changes when using the `excludeNonRelevant` setting. Prior to this change, the implementation would perform some unnecessary DOM operations (rewriting blank values to nodes which were already blank), and often many unnecessary downstream computations (dispatching `DataUpdate` events for those same nodes). This change will particularly benefit forms where a relevance change cascades to a large number of blank/unfilled elements.