### PR TITLE
Optimizations: do less redundant work, part 2

### DIFF
--- a/src/js/calculate.js
+++ b/src/js/calculate.js
@@ -141,12 +141,12 @@ export default {
             // https://github.com/OpenClinica/enketo-express-oc/issues/355#issuecomment-725640823
             return [
                 ...this.form.view.html.querySelectorAll(
-                    `.${action} [data-${action}][data-event*="${event.type}"]`
+                    `.non-form-control-action[data-${action}].odk-instance-first-load`
                 ),
             ].concat(
                 this.form.filterRadioCheckSiblings([
                     ...this.form.view.html.querySelectorAll(
-                        `.question [data-${action}][data-event*="${event.type}"]`
+                        `.form-control-action[data-${action}].odk-instance-first-load`
                     ),
                 ])
             );
@@ -160,7 +160,7 @@ export default {
             return this.form
                 .getRelatedNodes(
                     `data-${action}`,
-                    `.${action} [data-event*="${event.type}"]`,
+                    '.non-form-control-action.odk-new-repeat',
                     event.detail
                 )
                 .get()
@@ -168,7 +168,7 @@ export default {
                     this.form
                         .getRelatedNodes(
                             `data-${action}`,
-                            `.question [data-event*="${event.type}"]`,
+                            '.form-control-action.odk-new-repeat',
                             event.detail
                         )
                         .get()
@@ -179,12 +179,12 @@ export default {
 
             return question
                 ? [
-                      ...question.querySelectorAll(
-                          `[data-${action}][data-event*="${event.type}"]`
-                      ),
-                  ]
+                      ...question.querySelectorAll('.xforms-value-changed'),
+                  ].filter((el) => el.dataset[action] != null)
                 : [];
         }
+
+        return [];
     },
 
     /**

--- a/src/js/dom/collections.js
+++ b/src/js/dom/collections.js
@@ -1,0 +1,506 @@
+// @ts-check
+
+import { commentTreeWalker, findMarkerComments } from './tree-walker';
+
+/**
+ * @typedef {import('./tree-walker').CommentTreeWalker} CommentTreeWalker
+ */
+
+/**
+ * @typedef {import('../form').Form} Form
+ */
+
+/**
+ * @typedef {TreeWalker & { currentNode: ProcessingInstruction }} ProcessingInstructionTreeWalker
+ */
+
+const BREAK = Symbol('BREAK');
+
+/**
+ * @typedef {typeof BREAK} Break
+ */
+
+/** @type {Set<string>} */
+let activeIds = new Set();
+
+/** @type {Set<RefIndexedDOMCollection>} */
+let collections = new Set();
+
+/**
+ * @package - exported only for unit tests
+ * @template {string} [CollectionID=string]
+ */
+export class RefIndexedDOMCollection {
+    /**
+     * @param {CollectionID} id
+     * @param {Form} form
+     * @param {HTMLElement} rootElement
+     * @param {string} selector
+     * @param {string} [refAttr]
+     */
+    constructor(id, form, rootElement, selector, refAttr) {
+        if (activeIds.has(id)) {
+            throw new Error(
+                `The id parameter must be unique per form, "${id}" is already used`
+            );
+        }
+
+        collections.add(this);
+
+        /** @type {string} */
+        this.id = id;
+
+        /** @type {Form} */
+        this.form = form;
+
+        /** @type {HTMLElement} */
+        this.rootElement = rootElement;
+
+        /** @type {string} */
+        this.prefix = `${id}:`;
+
+        /** @type {string} */
+        this.selector = selector;
+
+        /** @type {string | null} */
+        this.refAttr = refAttr ?? null;
+
+        /** @type {Set<string>} */
+        this.refs = new Set();
+
+        /** @type {Set<string>} */
+        this.repeatDescendantRefs = new Set();
+
+        /** @type {Set<string>} */
+        this.topLevelGroupRefs = new Set();
+
+        /**
+         * @private
+         * @type {Map<string, WeakMap<HTMLElement, number>>}
+         */
+        this.refIndexCache = new Map([['', new WeakMap()]]);
+
+        /**
+         * @private
+         * @type {Map<string, HTMLElement[]>}
+         */
+        this.refElementsCache = new Map();
+
+        const { refs } = this;
+
+        const elements = /** @type {NodeListOf<HTMLElement>} */ (
+            rootElement.querySelectorAll(selector)
+        );
+        const firstElement = elements[0];
+
+        const isNoop =
+            firstElement == null || firstElement.parentElement == null;
+
+        /** @type {boolean} */
+        this.isNoop = isNoop;
+
+        /** @type {HTMLElement} */
+        this.startElement = isNoop
+            ? rootElement
+            : /** @type {HTMLElement} */ (
+                  firstElement?.previousElementSibling ?? rootElement
+              );
+
+        /** @type {HTMLElement} */
+        this.startElementContainer = isNoop
+            ? rootElement
+            : this.startElement.closest('.or-group') ?? rootElement;
+
+        const elementName = firstElement?.nodeName.toLowerCase();
+
+        /**
+         * @private
+         * @type {'nextElementSibling' | 'parentElement'}
+         */
+        this.commentToElementKey =
+            elementName === 'input' ? 'nextElementSibling' : 'parentElement';
+
+        /**
+         * Inserts `comment` into the DOM so `element` can be efficiently found
+         * with a tree walker. In most cases `comment` is prepended to `element`
+         * so it will be included in clones. The exception is for input
+         * elements, which are not supposed to have child elements.
+         *
+         * @type {(element: HTMLElement, comment: Comment) => void}
+         */
+        const insert =
+            elementName === 'input'
+                ? (element, comment) => {
+                      element.before(comment);
+                  }
+                : (element, comment) => {
+                      element.prepend(comment);
+                  };
+
+        const isFormStatic = form.initialized
+            ? !form.features.repeat
+            : rootElement.querySelector('.or-repeat') == null;
+
+        elements.forEach((element) => {
+            const ref = refAttr == null ? '' : element.getAttribute(refAttr);
+
+            if (ref == null) {
+                return;
+            }
+
+            if (!this.refs.has(ref)) {
+                refs.add(ref);
+
+                if (!isFormStatic && element.closest('.or-repeat') != null) {
+                    this.repeatDescendantRefs.add(ref);
+                    this.refIndexCache.set(ref, new WeakMap());
+                } else {
+                    this.refElementsCache.set(ref, [element]);
+                    this.refIndexCache.set(ref, new WeakMap([[element, 0]]));
+                }
+            }
+
+            const comment = document.createComment(`${id}:${ref}`);
+
+            insert(element, comment);
+        });
+
+        /** @type {boolean} */
+        this.isStatic =
+            this.isNoop ||
+            (form.initialized
+                ? !form.features.repeat
+                : rootElement.querySelector('.or-repeat') == null) ||
+            this.repeatDescendantRefs.size === 0;
+    }
+
+    reset() {
+        this.isNoop = true;
+        this.isStatic = true;
+        this.refs = new Set();
+        this.repeatDescendantRefs = new Set();
+        this.topLevelGroupRefs = new Set();
+        this.refIndexCache = new Map([['', new WeakMap()]]);
+        this.refElementsCache = new Map();
+        this.rootElement = document.createElement('no-op');
+    }
+    /**
+     * @param {string} repeatPath
+     */
+
+    invalidate(repeatPath) {
+        if (this.isNoop || this.isStatic) {
+            return;
+        }
+
+        this.refElementsCache.delete('');
+        this.refIndexCache.set('', new WeakMap());
+
+        let affectedRefs = Array.from(this.repeatDescendantRefs);
+
+        if (repeatPath != null) {
+            const prefix = `${repeatPath}/`;
+
+            affectedRefs = affectedRefs.filter((ref) => {
+                const isAffected = ref === repeatPath || ref.startsWith(prefix);
+
+                return isAffected;
+            });
+        }
+
+        for (const ref of affectedRefs) {
+            this.refElementsCache.delete(ref);
+            this.refIndexCache.set(ref, new WeakMap());
+        }
+    }
+
+    /**
+     * @param {string} ref
+     */
+    hasRef(ref) {
+        return this.refs.has(ref);
+    }
+
+    /**
+     * @private
+     * @param {(element: HTMLElement, index: number) => Break | void} callback
+     * @param {{ matchRef?: string | null }} [options]
+     */
+    walk(callback, options = {}) {
+        const { isNoop, prefix, rootElement } = this;
+
+        if (isNoop) {
+            return;
+        }
+
+        const { matchRef } = options;
+        let index = 0;
+        let { startElement, startElementContainer } = this;
+
+        if (!startElementContainer.isConnected) {
+            startElementContainer = rootElement;
+            this.startElementContainer = startElementContainer;
+        }
+
+        if (!startElement.isConnected) {
+            startElement = startElementContainer.isConnected
+                ? startElementContainer
+                : this.rootElement;
+
+            this.startElement = startElement;
+        }
+
+        const matchData = matchRef ? `${prefix}${matchRef}` : null;
+        const comments = findMarkerComments(
+            rootElement,
+            matchData == null
+                ? (commentData) => commentData.startsWith(prefix)
+                : (commentData) => commentData === matchData,
+            { startElement }
+        );
+
+        const { commentToElementKey } = this;
+
+        for (const comment of comments) {
+            const element = /** @type {HTMLElement} */ (
+                comment[commentToElementKey]
+            );
+            const result = callback(element, index);
+
+            if (result === BREAK) {
+                break;
+            }
+
+            index += 1;
+        }
+    }
+
+    /**
+     * @private
+     * @param {{ cacheIndexes?: boolean; matchRef?: string | null; }} [options]
+     */
+    collect(options = {}) {
+        const { cacheIndexes = false, matchRef } = options;
+
+        /** @type {HTMLElement[]} */
+        const elements = [];
+
+        this.walk(
+            (element, index) => {
+                elements.push(element);
+
+                if (cacheIndexes) {
+                    this.setRefIndexCache(element, index);
+                }
+            },
+            { matchRef }
+        );
+
+        return elements;
+    }
+
+    /**
+     * @private
+     * @param {HTMLElement} element
+     * @param {{ cacheIndexes?: boolean; matchRef?: string | null; }} [options]
+     */
+    getIndex(element, options = {}) {
+        const { matchRef, cacheIndexes = matchRef != null } = options;
+        let result = -1;
+
+        this.walk(
+            (item, index) => {
+                if (cacheIndexes) {
+                    this.setRefIndexCache(item, index, matchRef ?? '');
+                }
+
+                if (item === element) {
+                    result = index;
+
+                    return BREAK;
+                }
+            },
+            { matchRef }
+        );
+
+        return result;
+    }
+
+    getElements() {
+        return this.getElementsByRef('');
+    }
+
+    getElement(index = 0) {
+        return this.getElements()[index];
+    }
+
+    /**
+     * @param {string} ref
+     */
+    getElementsByRef(ref) {
+        if (this.isNoop) {
+            return [];
+        }
+
+        let elements = this.refElementsCache.get(ref);
+
+        if (elements == null) {
+            const cacheIndexes = ref !== '' || this.refAttr == null;
+            const matchRef = ref || null;
+
+            elements = this.collect({
+                cacheIndexes,
+                matchRef,
+            });
+
+            this.refElementsCache.set(ref, elements);
+        }
+
+        return elements;
+    }
+
+    /**
+     * @param {string} ref
+     */
+    getElementByRef(ref, index = 0) {
+        return this.getElementsByRef(ref)[index];
+    }
+
+    /**
+     * @param {HTMLElement} element
+     */
+    indexOf(element) {
+        if (this.isNoop) {
+            return 0;
+        }
+
+        return this.getIndex(element);
+    }
+
+    /**
+     * @param {HTMLElement} element
+     * @param {number} index
+     * @param {string} [ref]
+     */
+    setRefIndexCache(
+        element,
+        index,
+        ref = this.refAttr == null
+            ? ''
+            : element.getAttribute(this.refAttr) ?? ''
+    ) {
+        let cache = this.refIndexCache.get(ref);
+
+        if (cache == null) {
+            cache = new WeakMap();
+
+            this.refIndexCache.set(ref, cache);
+        }
+
+        cache.set(element, index);
+    }
+
+    /**
+     * @param {HTMLElement} element
+     * @param {string} ref
+     */
+    refIndexOf(element, ref) {
+        if (this.isNoop) {
+            return 0;
+        }
+
+        let index = this.refIndexCache.get(ref)?.get(element);
+
+        if (
+            index == null ||
+            (index === -1 && this.rootElement.contains(element))
+        ) {
+            index = this.getIndex(element, {
+                matchRef: ref,
+            });
+
+            this.setRefIndexCache(element, index);
+        }
+
+        return index;
+    }
+}
+
+/**
+ * @param {Form} form
+ */
+export const initCollections = (form) => {
+    const rootElement = form.view.html;
+
+    commentTreeWalker.currentNode = rootElement;
+
+    while (commentTreeWalker.nextNode() != null) {
+        // Perhaps counterintuitively, performing an initial walk can sometimes improve form load time by ~500ms for large forms!
+    }
+
+    const actions = {
+        valueChanged: form.features.valueChangedAction
+            ? new RefIndexedDOMCollection(
+                  'valueChangedActions',
+                  form,
+                  rootElement,
+                  '.xforms-value-changed',
+                  'name'
+              )
+            : null,
+    };
+    const groups = new RefIndexedDOMCollection(
+        'groups',
+        form,
+        rootElement,
+        '.or-group, .or-group-data',
+        'name'
+    );
+    const refTargetContainers = new RefIndexedDOMCollection(
+        'refTargetContainers',
+        form,
+        rootElement,
+        '.contains-ref-target',
+        'data-contains-ref-target'
+    );
+    const repeats = new RefIndexedDOMCollection(
+        'repeats',
+        form,
+        rootElement,
+        '.or-repeat',
+        'name'
+    );
+    const repeatInfos = new RefIndexedDOMCollection(
+        'repeatInfos',
+        form,
+        rootElement,
+        '.or-repeat-info',
+        'data-name'
+    );
+
+    return {
+        actions,
+        groups,
+        refTargetContainers,
+        repeats,
+        repeatInfos,
+    };
+};
+
+/**
+ * @param {string} repeatPath
+ */
+export const invalidateRepeatCaches = (repeatPath) => {
+    for (const collection of collections) {
+        collection.invalidate(repeatPath);
+    }
+};
+
+export const resetCollections = () => {
+    for (const collection of collections) {
+        collection.reset();
+    }
+
+    activeIds = new Set();
+    collections = new Set();
+};

--- a/src/js/dom/collections.js
+++ b/src/js/dom/collections.js
@@ -27,6 +27,27 @@ let activeIds = new Set();
 let collections = new Set();
 
 /**
+ * Provides consistent, efficient access to common operations on DOM collections which:
+ *
+ * - Have an identifiable role or type
+ * - Have been transformed by Enketo Transformer to have a known attribute name
+ *   whose value is a stable model nodeset reference, where existing form logic
+ *   is concerned with:
+ *     - finding elements of a given role by a given reference
+ *     - identifying the presence of said reference in a form, or in another
+ *       element's hierarchy
+ * - Are indexed by their [containing] repeat instance on forms with repeats,
+ *   where existing form logic is concerned with:
+ *     - determining their current index position
+ *     - finding an element with a given role/reference at a specified index
+ *       position
+ *
+ * These collections are looked up, and cached, by their role/type, as well as
+ * by their model nodeset reference. For forms with repeat functionality, their
+ * repeat index positions are also cached, invalidating caches of repeats and
+ * their descendants when instances are added or removed. For forms without
+ * repet functionality, each collection is cached for the duration of form entry.
+ *
  * @package - exported only for unit tests
  * @template {string} [CollectionID=string]
  */
@@ -427,6 +448,8 @@ export class RefIndexedDOMCollection {
 }
 
 /**
+ * Initializes collections of stable or highly cacheable DOM elements. @see {@link RefIndexedDOMCollection}
+ *
  * @param {Form} form
  */
 export const initCollections = (form) => {

--- a/src/js/dom/features.js
+++ b/src/js/dom/features.js
@@ -5,6 +5,10 @@
  */
 
 /**
+ * Detects statically identifiable (during init) features which may used by a
+ * given form, allowing forms without certain features to skip
+ * unused-but-expensive functionality.
+ *
  * @param {HTMLFormElement} formElement
  */
 export const detectFeatures = (formElement) => {

--- a/src/js/dom/features.js
+++ b/src/js/dom/features.js
@@ -1,0 +1,52 @@
+// @ts-check
+
+/**
+ * @typedef {import('../form').Form} Form
+ */
+
+/**
+ * @param {HTMLFormElement} formElement
+ */
+export const detectFeatures = (formElement) => {
+    const action = formElement.querySelector('.action') != null;
+    const calculate =
+        action || formElement.querySelector('[data-calculate]') != null;
+    const instanceFirstLoadAction =
+        action && formElement.querySelector('.odk-instance-first-load') != null;
+    const itemset = formElement.querySelector('.itemset-template') != null;
+    const newRepeatAction =
+        action && formElement.querySelector('.odk-new-repeat') != null;
+    const output = formElement.querySelector('.or-output') != null;
+    const pagination = formElement.classList.contains('pages');
+    const relevant = formElement.querySelector('[data-relevant]') != null;
+    const repeat = formElement.querySelector('.or-repeat') != null;
+    const repeatClone =
+        repeat && formElement.querySelector('.or-repeat.clone') != null;
+    const repeatCount =
+        repeat &&
+        formElement.querySelector('.or-repeat-info[data-repeat-count]') != null;
+    const required = formElement.querySelector('[data-required]') != null;
+    const valueChangedAction =
+        formElement.querySelector('.xforms-value-changed') != null;
+
+    return {
+        action,
+        calculate,
+        instanceFirstLoadAction,
+        itemset,
+        newRepeatAction,
+        output,
+        pagination,
+        relevant,
+
+        /**
+         * This will be updated in repeat.js as repeats are added/removed.
+         */
+        repeatClone,
+
+        repeatCount,
+        repeat,
+        required,
+        valueChangedAction,
+    };
+};

--- a/src/js/dom/features.js
+++ b/src/js/dom/features.js
@@ -20,8 +20,6 @@ export const detectFeatures = (formElement) => {
     const pagination = formElement.classList.contains('pages');
     const relevant = formElement.querySelector('[data-relevant]') != null;
     const repeat = formElement.querySelector('.or-repeat') != null;
-    const repeatClone =
-        repeat && formElement.querySelector('.or-repeat.clone') != null;
     const repeatCount =
         repeat &&
         formElement.querySelector('.or-repeat-info[data-repeat-count]') != null;
@@ -38,12 +36,6 @@ export const detectFeatures = (formElement) => {
         output,
         pagination,
         relevant,
-
-        /**
-         * This will be updated in repeat.js as repeats are added/removed.
-         */
-        repeatClone,
-
         repeatCount,
         repeat,
         required,

--- a/src/js/dom/index.js
+++ b/src/js/dom/index.js
@@ -1,0 +1,15 @@
+/**
+ * These exports from the collections, features, refs and tree-walker modules
+ * are used to implement several performance optimizations around aspects of a
+ * form which are static or highly cacheable. See each export's JSDoc for
+ * further details.
+ */
+
+export {
+    initCollections,
+    invalidateRepeatCaches,
+    resetCollections,
+} from './collections';
+export { detectFeatures } from './features';
+export { setRefTypeClasses } from './refs';
+export { findMarkerComment, findMarkerComments } from './tree-walker';

--- a/src/js/dom/refs.js
+++ b/src/js/dom/refs.js
@@ -1,0 +1,94 @@
+// @ts-check
+
+/**
+ * @typedef {import('../form').Form} Form
+ */
+
+/**
+ * Sets convenience classes on DOM elements with model references, to optmize:
+ *
+ * - identifying action references (and their event types) and distinguish them from non-action references
+ * - identifying controls and their pertinent container elements by their reference
+ *
+ * @param {Form} form
+ */
+export const setRefTypeClasses = (form) => {
+    const rootElement = form.view.html;
+
+    const hasActions =
+        rootElement.querySelector('[data-setvalue], [data-setgeopoint]') !=
+        null;
+
+    const selector = hasActions
+        ? '[name], [data-name], [data-setvalue], [data-setgeopoint]'
+        : '.question [name], .question [data-name]';
+
+    const elements = /** @type {NodeListOf<HTMLElement>} */ (
+        rootElement.querySelectorAll(selector)
+    );
+
+    const eventTypes = [
+        'odk-instance-first-load',
+        'odk-new-repeat',
+        'xforms-value-changed',
+    ];
+
+    const nonEventClasses = eventTypes.map((event) => `non-${event}`);
+
+    /** @type {string[]} */
+    let classes = [];
+
+    for (const element of elements) {
+        if (hasActions) {
+            const isAction =
+                element.dataset.setvalue != null ||
+                element.dataset.setgeopoint != null;
+            const isFormControlAction =
+                isAction && element.closest('.question') != null;
+            const actionClasses = [
+                isAction ? 'action' : 'non-action',
+                isFormControlAction
+                    ? 'form-control-action'
+                    : 'non-form-control-action',
+            ];
+            const elementEvents = isAction
+                ? element.dataset.event?.trim()?.split(/\s+/) ?? []
+                : [];
+            const eventClasses = isAction
+                ? eventTypes.map((event, index) =>
+                      elementEvents.includes(event)
+                          ? event
+                          : nonEventClasses[index]
+                  )
+                : nonEventClasses;
+
+            classes = [...actionClasses, ...eventClasses];
+
+            element.classList.add(...classes);
+        }
+
+        if (
+            !hasActions ||
+            !element.matches(
+                '.or-group, .or-group-data, .or-repeat, .or-repeat-info, .question [data-event="xforms-value-changed"]'
+            )
+        ) {
+            const ref = element.dataset.name ?? element.getAttribute('name');
+
+            if (ref == null) {
+                return;
+            }
+
+            const container = /** @type {HTMLElement} */ (
+                element.closest('.itemset-template') ??
+                    // @ts-ignore
+                    form.input.getWrapNode(element)
+            );
+
+            element.classList.add('ref-target');
+            container.classList.add('contains-ref-target');
+            container.dataset.containsRefTarget = ref;
+            element.dataset.ref = ref;
+        }
+    }
+};

--- a/src/js/dom/refs.js
+++ b/src/js/dom/refs.js
@@ -5,10 +5,16 @@
  */
 
 /**
- * Sets convenience classes on DOM elements with model references, to optmize:
+ * Sets convenience classes and related annotations on DOM elements with model
+ * references, to optimize:
  *
- * - identifying action references (and their event types) and distinguish them from non-action references
- * - identifying controls and their pertinent container elements by their reference
+ * - identifying action references (and their event types) and distinguish them
+ *   from non-action references
+ * - identifying controls and their pertinent container elements by their
+ *   reference
+ *
+ * These annotations allow simplification of many DOM lookups, and in many cases
+ * allow formerly dynamic queries to be static.
  *
  * @param {Form} form
  */

--- a/src/js/dom/tree-walker.js
+++ b/src/js/dom/tree-walker.js
@@ -1,0 +1,91 @@
+// @ts-check
+
+/**
+ * @typedef {TreeWalker & { set currentNode(node: Node); get currentNode():  Comment }} CommentTreeWalker
+ */
+
+export const commentTreeWalker = /** @type {CommentTreeWalker} */ (
+    document.createTreeWalker(document.documentElement, NodeFilter.SHOW_COMMENT)
+);
+
+/**
+ * @typedef FindMarkerCommentsOptions
+ * @property {number} [maxItems]
+ * @property {Element | null} [startElement]
+ */
+
+/**
+ * @param {Element} parentElement
+ * @param {(commentValue: string) => boolean} filter
+ * @param {FindMarkerCommentsOptions} [options]
+ */
+export const findMarkerComments = (parentElement, filter, options = {}) => {
+    const { maxItems, startElement } = options;
+    const initialCurrentNode = commentTreeWalker.currentNode;
+
+    commentTreeWalker.currentNode = startElement ?? parentElement;
+
+    /** @type {Comment[]} */
+    const comments = [];
+
+    while (commentTreeWalker.nextNode() != null) {
+        const comment = commentTreeWalker.currentNode;
+
+        if (!parentElement.contains(comment)) {
+            break;
+        }
+
+        if (filter(comment.data)) {
+            comments.push(comment);
+
+            if (maxItems != null && comments.length === maxItems) {
+                break;
+            }
+        }
+    }
+
+    commentTreeWalker.currentNode = initialCurrentNode;
+
+    return comments;
+};
+
+/**
+ * @param {Element} element
+ * @param {string} value
+ * @param {number} index
+ */
+export const findMarkerComment = (element, value, index) => {
+    // const comments = findMarkerComments(
+    //     element,
+    //     (commentValue) => commentValue === value,
+    //     { maxItems: index + 1 }
+    // );
+
+    // return comments[index];
+    const initialCurrentNode = commentTreeWalker.currentNode;
+
+    commentTreeWalker.currentNode = element;
+
+    let found = -1;
+
+    /** @type {Comment | null} */
+    let result = null;
+
+    while (found < index && commentTreeWalker.nextNode() != null) {
+        const comment = /** @type {Comment} */ (commentTreeWalker.currentNode);
+
+        if (comment.data === value) {
+            found += 1;
+
+            if (found === index) {
+                result = comment;
+
+                break;
+            }
+        }
+    }
+
+    commentTreeWalker.currentNode = initialCurrentNode;
+
+    return result;
+};

--- a/src/js/dom/tree-walker.js
+++ b/src/js/dom/tree-walker.js
@@ -15,6 +15,17 @@ export const commentTreeWalker = /** @type {CommentTreeWalker} */ (
  */
 
 /**
+ * @typedef {import('./collections').RefIndexedDOMCollection} RefIndexedDOMCollection
+ */
+
+/**
+ * @typedef {import('../form-model').FormModel} FormModel
+ */
+
+/**
+ * Finds comments which have been added to the DOM as markers to locate
+ * associated form features, e.g. view elements of a certain role/type and ref (@see {@link RefIndexedDOMCollection}) or insertion points for repeat instance model elements (@see {@link FormModel['getRepeatCommentNode']}).
+ *
  * @param {Element} parentElement
  * @param {(commentValue: string) => boolean} filter
  * @param {FindMarkerCommentsOptions} [options]

--- a/src/js/event.js
+++ b/src/js/event.js
@@ -73,27 +73,49 @@ function NewRepeat(detail) {
 }
 
 /**
+ * @typedef {'magic' | 'user' | 'count' | 'model'} AddRepeatTrigger
+ */
+
+/**
+ * @typedef AddRepeatDetail
+ * @property {string} repeatPath
+ * @property {number} repeatIndex
+ * @property {AddRepeatTrigger} trigger
+ */
+
+/**
  * The addrepeat event is similar but fired under different circumstances.
  *
- * @param {{repeatPath: string, repeatIndex: number, trigger: string}} detail - Data to be passed with event.
- * @return {CustomEvent} Custom "odk-new-repeat" event (bubbling)
+ * @param {AddRepeatDetail} [detail] - Data to be passed with event.
+ * @return {CustomEvent<AddRepeatDetail> & { type: 'addrepeat' }} Custom "odk-new-repeat" event (bubbling)
  */
-function AddRepeat(detail) {
+function AddRepeat(detail = {}) {
     return new CustomEvent('addrepeat', { detail, bubbles: true });
 }
 
 /**
- * @typedef RemoveRepeatDetail
+ * @typedef InitRemoveRepeatDetail
  * @property {object} [initRepeatInfo]
  * @property {string} [initRepeatInfo.repeatPath]
  * @property {number} [initRepeatInfo.repeatIndex]
  */
 
 /**
+ * @typedef PostInitRemoveRepeatDetail
+ * @property {object} [initRepeatInfo]
+ * @property {string} [initRepeatInfo.repeatPath]
+ * @property {number} [initRepeatInfo.repeatIndex]
+ */
+
+/**
+ * @typedef {InitRemoveRepeatDetail | PostInitRemoveRepeatDetail} RemoveRepeatDetail
+ */
+
+/**
  * Remove repeat event.
  *
  * @param {RemoveRepeatDetail} [detail]
- * @return {CustomEvent} Custom "removerepeat" event (bubbling)
+ * @return {CustomEvent<RemoveRepeatDetail> & { type: 'removerepeat' }} Custom "removerepeat" event (bubbling)
  */
 function RemoveRepeat(detail) {
     return new CustomEvent('removerepeat', { detail, bubbles: true });

--- a/src/js/form-model.js
+++ b/src/js/form-model.js
@@ -1,6 +1,7 @@
 import MergeXML from 'mergexml/mergexml';
 import config from 'enketo/config';
 import bindJsEvaluator from 'enketo/xpath-evaluator-binding';
+import { findMarkerComment } from './dom/tree-walker';
 import { readCookie, parseFunctionFromExpression, stripQuotes } from './utils';
 import {
     getSiblingElementsAndSelf,
@@ -633,19 +634,17 @@ FormModel.prototype.getRepeatCommentSelector = function (repeatPath) {
 /**
  * @param {string} repeatPath - path to repeat
  * @param {number} repeatSeriesIndex - index of repeat series
- * @return {Element} node
+ * @return {Node} node
  */
-FormModel.prototype.getRepeatCommentEl = function (
+FormModel.prototype.getRepeatCommentNode = function (
     repeatPath,
     repeatSeriesIndex
 ) {
-    return this.evaluate(
-        this.getRepeatCommentSelector(repeatPath),
-        'nodes-ordered',
-        null,
-        null,
-        true
-    )[repeatSeriesIndex];
+    return findMarkerComment(
+        this.xml.documentElement,
+        this.getRepeatCommentText(repeatPath),
+        repeatSeriesIndex
+    );
 };
 
 /**
@@ -674,7 +673,7 @@ FormModel.prototype.addRepeat = function (
     const repeatSeries = this.getRepeatSeries(repeatPath, repeatSeriesIndex);
     const insertAfterNode = repeatSeries.length
         ? repeatSeries[repeatSeries.length - 1]
-        : this.getRepeatCommentEl(repeatPath, repeatSeriesIndex);
+        : this.getRepeatCommentNode(repeatPath, repeatSeriesIndex);
 
     // if not exists and not a merge operation
     if (!merge) {
@@ -781,7 +780,7 @@ FormModel.prototype.getRepeatSeries = function (repeatPath, repeatSeriesIndex) {
     let pathSegments;
     let nodeName;
     let checkEl;
-    const repeatCommentEl = this.getRepeatCommentEl(
+    const repeatCommentEl = this.getRepeatCommentNode(
         repeatPath,
         repeatSeriesIndex
     );

--- a/src/js/form-model.js
+++ b/src/js/form-model.js
@@ -1,7 +1,7 @@
 import MergeXML from 'mergexml/mergexml';
 import config from 'enketo/config';
 import bindJsEvaluator from 'enketo/xpath-evaluator-binding';
-import { findMarkerComment } from './dom/tree-walker';
+import { findMarkerComment } from './dom';
 import { readCookie, parseFunctionFromExpression, stripQuotes } from './utils';
 import {
     getSiblingElementsAndSelf,

--- a/src/js/form-model.js
+++ b/src/js/form-model.js
@@ -722,14 +722,14 @@ FormModel.prototype.addOrdinalAttribute = function (
     repeat,
     firstRepeatInSeries
 ) {
-    let lastUsedOrdinal;
-    let newOrdinal;
-    const enkNs = this.getNamespacePrefix(ENKETO_XFORMS_NS);
-    firstRepeatInSeries = firstRepeatInSeries || repeat;
     if (
         config.repeatOrdinals === true &&
         !repeat.getAttributeNS(ENKETO_XFORMS_NS, 'ordinal')
     ) {
+        let lastUsedOrdinal;
+        let newOrdinal;
+        const enkNs = this.getNamespacePrefix(ENKETO_XFORMS_NS);
+        firstRepeatInSeries = firstRepeatInSeries || repeat;
         // getAttributeNs and setAttributeNs results in duplicate namespace declarations on each repeat node in IE11 when serializing the model.
         // However, the regular getAttribute and setAttribute do not work properly in IE11.
         lastUsedOrdinal =

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -35,6 +35,7 @@ import events from './event';
 import './plugins';
 import './extend';
 import { callOnIdle } from './timers';
+import { setRefTypeClasses } from './dom/refs';
 
 /**
  * @typedef FormOptions
@@ -50,7 +51,7 @@ import { callOnIdle } from './timers';
  *
  * Most methods are prototype method to facilitate customizations outside of enketo-core.
  *
- * @param {Element} formEl - HTML form element (a product of Enketo Transformer after transforming a valid ODK XForm)
+ * @param {HTMLFormElement} formEl - HTML form element (a product of Enketo Transformer after transforming a valid ODK XForm)
  * @param {FormDataObj} data - Data object containing XML model, (partial) XML instance-to-load, external data and flag about whether instance-to-load has already been submitted before.
  * @param {FormOptions} [options]
  * @class
@@ -301,6 +302,7 @@ Form.prototype.init = function () {
         this.calc.performAction('setvalue', event);
         this.calc.performAction('setgeopoint', event);
     });
+    setRefTypeClasses(this);
 
     // Handle xforms-value-changed
     this.view.html.addEventListener(

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -70,10 +70,16 @@ function Form(formEl, data, options) {
     this.all = {};
     this.options = options ?? {};
 
+    const formHTML = formEl.outerHTML;
+
     this.view = {
         $: $form,
         html: formEl,
-        clone: formEl.cloneNode(true),
+        get clone() {
+            const range = document.createRange();
+
+            return range.createContextualFragment(formHTML).firstElementChild;
+        },
     };
     this.model = new FormModel(data);
     this.repeatsPresent = !!this.view.html.querySelector('.or-repeat');

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -35,9 +35,12 @@ import events from './event';
 import './plugins';
 import './extend';
 import { callOnIdle } from './timers';
-import { setRefTypeClasses } from './dom/refs';
-import { initCollections, resetCollections } from './dom/collections';
-import { detectFeatures } from './dom/features';
+import {
+    detectFeatures,
+    initCollections,
+    resetCollections,
+    setRefTypeClasses,
+} from './dom';
 
 /**
  * @typedef FormOptions

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -257,8 +257,9 @@ Form.prototype = {
 /**
  * Returns a module and adds the form property to it.
  *
- * @param {object} module - Enketo Core module
- * @return {object} updated module
+ * @template T
+ * @param {T} module - Enketo Core module
+ * @return {T & { form: Form }} updated module
  */
 Form.prototype.addModule = function (module) {
     return Object.create(module, {
@@ -819,6 +820,10 @@ Form.prototype.getRelatedNodes = function (attr, filter, updated) {
         collection = this.all[attr];
     }
 
+    if (collection.length === 0) {
+        return $(collection);
+    }
+
     let selector = [];
     // Add selectors based on specific changed nodes
     if (!updated.nodes || updated.nodes.length === 0) {
@@ -843,10 +848,13 @@ Form.prototype.getRelatedNodes = function (attr, filter, updated) {
         );
     }
 
+    if (selector.length === 0) {
+        return $(collection);
+    }
+
     const selectorStr = selector.join(', ');
-    collection = selectorStr
-        ? collection.filter((el) => el.matches(selectorStr))
-        : collection;
+
+    collection = collection.filter((el) => el.matches(selectorStr));
 
     // TODO: exclude descendents of disabled elements? .find( ':not(:disabled) span.active' )
     // TODO: remove jQuery wrapper, just return array of elements
@@ -1312,7 +1320,7 @@ Form.prototype.validateContent = function ($container) {
         .map(function () {
             // only trigger validate on first input and use a **pure CSS** selector (huge performance impact)
             const elem = this.querySelector(
-                'input:not(.ignore):not(:disabled), select:not(.ignore):not(:disabled), textarea:not(.ignore):not(:disabled)'
+                'input:enabled:not(.ignore), select:enabled:not(.ignore), textarea:enabled:not(.ignore)'
             );
             if (!elem) {
                 return Promise.resolve();

--- a/src/js/input.js
+++ b/src/js/input.js
@@ -117,13 +117,18 @@ export default {
         return control.dataset.constraint;
     },
     /**
-     * @param {Element} control - form control HTML element
+     * @param {HTMLElement} control - form control HTML element
      * @return {string|undefined} required expression
      */
     getRequired(control) {
+        const { required } = control.dataset;
+
         // only return value if input is not a table heading input
-        if (!closestAncestorUntil(control, '.or-appearance-label', '.or')) {
-            return control.dataset.required;
+        if (
+            required != null &&
+            !closestAncestorUntil(control, '.or-appearance-label', '.or')
+        ) {
+            return required;
         }
     },
     /**

--- a/src/js/input.js
+++ b/src/js/input.js
@@ -12,10 +12,21 @@ import types from './types';
 import events from './event';
 import { closestAncestorUntil } from './dom-utils';
 
+/**
+ * @typedef {import('./form').Form} Form
+ */
+
 export default {
     /**
-     * @param {Element} control - form control HTML element
-     * @return {Element} Wrap node
+     * @type {Form}
+     */
+    // @ts-expect-error - this will be populated during form init, but assigning
+    // its type here improves intellisense.
+    form: null,
+
+    /**
+     * @param {HTMLElement} control - form control HTML element
+     * @return {HTMLElement} Wrap node
      */
     getWrapNode(control) {
         return control.closest(
@@ -243,22 +254,9 @@ export default {
      * @return {Element} found element
      */
     find(name, index = 0) {
-        let attr = 'name';
-        if (
-            this.form.view.html.querySelector(
-                `input[type="radio"][data-name="${name}"]:not(.ignore)`
-            )
-        ) {
-            attr = 'data-name';
-        }
-        const selector = `[${attr}="${name}"]:not([data-event="xforms-value-changed"])`;
-        const question = this.getWrapNodes(
-            this.form.view.html.querySelectorAll(selector)
-        )[index];
-
-        return question
-            ? question.querySelector(`[${attr}="${name}"]:not(.ignore)`)
-            : null;
+        return this.form.collections.refTargetContainers
+            .getElementByRef(name, index)
+            ?.querySelector('.ref-target:not(.ignore)');
     },
     /**
      * Sets the value of a form control (or group like radiobuttons)

--- a/src/js/itemset.js
+++ b/src/js/itemset.js
@@ -124,7 +124,6 @@ export default {
             return;
         }
 
-        const clonedRepeatsPresent = this.form.features.repeatClone;
         const alerts = [];
 
         nodes.forEach((template) => {
@@ -196,12 +195,7 @@ export default {
              * Determining the index is expensive, so we only do this when the itemset is inside a cloned repeat and not shared.
              * It can be safely set to 0 for other branches.
              */
-            const index =
-                !shared &&
-                clonedRepeatsPresent &&
-                input.closest('.or-repeat.clone')
-                    ? that.form.input.getIndex(input)
-                    : 0;
+            const index = !shared ? that.form.input.getIndex(input) : 0;
             const safeToTryNative = true;
             // Caching has no advantage here. This is a very quick query
             // (natively).

--- a/src/js/output.js
+++ b/src/js/output.js
@@ -42,11 +42,11 @@ export default {
         let val = '';
         const that = this;
 
-        const $nodes = this.form.getRelatedNodes(
-            'data-value',
-            '.or-output',
-            updated
-        );
+        const { rootNode } = updated ?? {};
+        const $nodes =
+            rootNode == null
+                ? this.form.getRelatedNodes('data-value', '.or-output', updated)
+                : $(rootNode.querySelectorAll('.or-output'));
 
         const clonedRepeatsPresent = this.form.features.repeatClone;
 

--- a/src/js/output.js
+++ b/src/js/output.js
@@ -48,8 +48,6 @@ export default {
                 ? this.form.getRelatedNodes('data-value', '.or-output', updated)
                 : $(rootNode.querySelectorAll('.or-output'));
 
-        const clonedRepeatsPresent = this.form.features.repeatClone;
-
         $nodes.each(function () {
             const $output = $(this);
             const output = this;
@@ -92,16 +90,8 @@ export default {
                 contextPath = null;
             }
 
-            const insideRepeat =
-                clonedRepeatsPresent &&
-                $output.parentsUntil('.or', '.or-repeat').length > 0;
-            const insideRepeatClone =
-                insideRepeat &&
-                $output.parentsUntil('.or', '.or-repeat.clone').length > 0;
-            const index =
-                insideRepeatClone && contextPath
-                    ? that.form.input.getIndex(context)
-                    : 0;
+            const insideRepeat = output.closest('.or-repeat') != null;
+            const index = contextPath ? that.form.input.getIndex(context) : 0;
 
             if (typeof outputCache[expr] !== 'undefined') {
                 val = outputCache[expr];

--- a/src/js/output.js
+++ b/src/js/output.js
@@ -4,7 +4,34 @@
 
 import $ from 'jquery';
 
+/**
+ * @typedef {import('./form').Form} Form
+ */
+
 export default {
+    /**
+     * @type {Form}
+     */
+    // @ts-expect-error - this will be populated during form init, but assigning
+    // its type here improves intellisense.
+    form: null,
+
+    init() {
+        if (!this.form) {
+            throw new Error(
+                'Output module not correctly instantiated with form property.'
+            );
+        }
+
+        if (!this.form.features.output) {
+            this.update = () => {};
+
+            return;
+        }
+
+        this.update();
+    },
+
     /**
      * Updates output values, optionally filtered by those values that contain a changed node name
      *
@@ -15,21 +42,13 @@ export default {
         let val = '';
         const that = this;
 
-        if (!this.form) {
-            throw new Error(
-                'Output module not correctly instantiated with form property.'
-            );
-        }
-
         const $nodes = this.form.getRelatedNodes(
             'data-value',
             '.or-output',
             updated
         );
 
-        const clonedRepeatsPresent =
-            this.form.repeatsPresent &&
-            this.form.view.html.querySelector('.or-repeat.clone');
+        const clonedRepeatsPresent = this.form.features.repeatClone;
 
         $nodes.each(function () {
             const $output = $(this);

--- a/src/js/page.js
+++ b/src/js/page.js
@@ -10,7 +10,18 @@ import events from './event';
 import { getSiblingElement, getAncestors } from './dom-utils';
 import 'jquery-touchswipe';
 
+/**
+ * @typedef {import('./form').Form} Form
+ */
+
 export default {
+    /**
+     * @type {Form}
+     */
+    // @ts-expect-error - this will be populated during form init, but assigning
+    // its type here improves intellisense.
+    form: null,
+
     /**
      * @type {boolean}
      * @default
@@ -34,7 +45,7 @@ export default {
                 'Repeats module not correctly instantiated with form property.'
             );
         }
-        if (this.form.view.html.classList.contains('pages')) {
+        if (this.form.features.pagination) {
             const allPages = [
                 ...this.form.view.html.querySelectorAll(
                     '.question, .or-appearance-field-list'

--- a/src/js/progress.js
+++ b/src/js/progress.js
@@ -33,12 +33,34 @@ export default {
             ),
         ].filter((question) => !question.closest('.disabled'));
     },
+
+    isUpdateScheduled: false,
+
+    /** @type {HTMLElement | null} */
+    scheduledUpdateElement: null,
+
     /**
      * Updates rounded % value of progress and triggers event if changed.
      *
      * @param {Element} el - the element that represent the current state of progress
      */
-    update(el) {
+    update(el, isScheduledCall = false) {
+        this.scheduledUpdateElement = el;
+
+        if (!isScheduledCall) {
+            if (!this.isUpdateScheduled) {
+                this.isUpdateScheduled = true;
+
+                queueMicrotask(() => {
+                    this.update(this.scheduledUpdateElement, true);
+                    this.isUpdateScheduled = false;
+                    this.scheduledUpdateElement = null;
+                });
+            }
+
+            return;
+        }
+
         let status;
 
         if (!this.all || !el) {

--- a/src/js/readonly.js
+++ b/src/js/readonly.js
@@ -2,7 +2,18 @@
  * @module readonly
  */
 
+/**
+ * @typedef {import('./form').Form} Form
+ */
+
 export default {
+    /**
+     * @type {Form}
+     */
+    // @ts-expect-error - this will be populated during form init, but assigning
+    // its type here improves intellisense.
+    form: null,
+
     /**
      * Updates readonly
      *
@@ -10,13 +21,14 @@ export default {
      */
     update(updated) {
         const nodes = this.form.getRelatedNodes('readonly', '', updated).get();
+
+        const { valueChanged } = this.form.collections.actions;
+
         nodes.forEach((node) => {
             node.closest('.question').classList.add('readonly');
 
             const path = this.form.input.getName(node);
-            const action = this.form.view.html.querySelector(
-                `[data-setvalue][data-event="xforms-value-changed"][name="${path}"], [data-setgeopoint][data-event="xforms-value-changed"][name="${path}"]`
-            );
+            const action = valueChanged?.hasRef(path);
 
             // Note: the readonly-forced class is added for special readonly views of a form.
             const empty =

--- a/src/js/relevant.js
+++ b/src/js/relevant.js
@@ -536,8 +536,7 @@ export default {
                 relevantPath: path,
             });
             // Update outputs that are children of branch
-            // TODO this re-evaluates all outputs in the form which is not efficient!
-            this.form.output.update();
+            this.form.output.update({ rootNode: branchNode });
             this.form.widgets.enable(branchNode);
             this.activate(branchNode);
         }

--- a/src/js/relevant.js
+++ b/src/js/relevant.js
@@ -169,11 +169,8 @@ export default {
                     const parentPath = pathParts
                         .splice(0, pathParts.length - 1)
                         .join('/');
-                    const parentGroups = [
-                        ...this.form.view.html.querySelectorAll(
-                            `.or-group[name="${parentPath}"],.or-group-data[name="${parentPath}"]`
-                        ),
-                    ]
+                    const parentGroups = groups
+                        .getElementsByRef(parentPath)
                         // now remove the groups that have a repeat-info child without repeat instance siblings
                         .filter(
                             (group) =>
@@ -231,9 +228,7 @@ export default {
                 (insideRepeat &&
                     repeatParent == null &&
                     (options.removed ||
-                        this.form.view.html.querySelector(
-                            `.or-repeat[name="${CSS.escape(repeatPath)}"]`
-                        ) == null))
+                        repeats.getElementByRef(repeatPath) == null))
             ) {
                 context = null;
             }
@@ -245,7 +240,7 @@ export default {
             p.ind =
                 hiddenInputRepeatIndex ??
                 (context && insideRepeatClone
-                    ? this.form.input.getIndex(node)
+                    ? this.form.repeats.getIndex(repeatParent)
                     : 0);
 
             /*

--- a/src/js/relevant.js
+++ b/src/js/relevant.js
@@ -111,7 +111,6 @@ export default {
         const relevantCache = {};
         const alreadyCovered = [];
         const repeatsPresent = this.form.features.repeat;
-        const clonedRepeatsPresent = this.form.features.repeatClone;
         const { groups, repeats } = this.form.collections;
 
         nodes.forEach((node) => {
@@ -206,11 +205,6 @@ export default {
                     ? repeatIndex
                     : null;
 
-            const insideRepeatClone =
-                hiddenInputRepeatIndex > 0 ||
-                (clonedRepeatsPresent &&
-                    repeatParent?.classList.contains('clone'));
-
             /*
              * If the relevant is placed on a group and that group contains repeats with the same name,
              * but currently has 0 repeats, the context will not be available. This same logic is applied in output.js.
@@ -235,9 +229,7 @@ export default {
              */
             const ind =
                 hiddenInputRepeatIndex ??
-                (context && insideRepeatClone
-                    ? this.form.repeats.getIndex(repeatParent)
-                    : 0);
+                this.form.repeats.getIndex(repeatParent);
 
             /*
              * Caching is only possible for expressions that do not contain relative paths to nodes.

--- a/src/js/repeat.js
+++ b/src/js/repeat.js
@@ -118,6 +118,10 @@ export default {
             .reverse()
             .each(function () {
                 const templateEl = this.cloneNode(true);
+                that.form.langs.setFormUi(
+                    that.form.currentLanguage,
+                    templateEl
+                );
                 const xPath = templateEl.getAttribute('name');
                 this.remove();
                 $(templateEl)

--- a/src/js/repeat.js
+++ b/src/js/repeat.js
@@ -23,7 +23,7 @@ import {
     getSiblingElementsAndSelf,
 } from './dom-utils';
 import { isStaticItemsetFromSecondaryInstance } from './itemset';
-import { invalidateRepeatCaches } from './dom/collections';
+import { invalidateRepeatCaches } from './dom';
 
 /**
  * @typedef {import('./form').Form} Form

--- a/src/js/repeat.js
+++ b/src/js/repeat.js
@@ -536,6 +536,14 @@ export default {
         const repeatIndex = this.getIndex($repeat[0]);
         const repeatInfo = $repeat.siblings('.or-repeat-info')[0];
 
+        if (
+            repeatIndex === 0 ||
+            $repeat.get(0).previousElementSibling?.getAttribute('name') !==
+                repeatPath
+        ) {
+            $next.get(0).classList.remove('clone');
+        }
+
         $repeat.remove();
 
         this.form.features.repeatClone =

--- a/src/js/repeat.js
+++ b/src/js/repeat.js
@@ -210,7 +210,7 @@ export default {
      * @param {HTMLElement} el
      */
     getIndex(el) {
-        if (!el || !this.form.features.repeatClone) {
+        if (!el) {
             return 0;
         }
 
@@ -400,8 +400,6 @@ export default {
             return false;
         }
 
-        this.form.features.repeatClone = true;
-
         const repeatPath = repeatInfo.dataset.name;
         const repeats = getSiblingElements(repeatInfo, '.or-repeat');
 
@@ -458,12 +456,6 @@ export default {
 
             // Insert the clone
             repeatInfo.before(clone);
-
-            if (repeatIndexInSeries > 0) {
-                // Also add the clone class for all 2+ numbers as this is
-                // used for performance optimization in several places.
-                clone.classList.add('clone');
-            }
 
             // Update the repeat number
             clone.querySelector('.repeat-number').textContent =
@@ -536,18 +528,7 @@ export default {
         const repeatIndex = this.getIndex($repeat[0]);
         const repeatInfo = $repeat.siblings('.or-repeat-info')[0];
 
-        if (
-            repeatIndex === 0 ||
-            $repeat.get(0).previousElementSibling?.getAttribute('name') !==
-                repeatPath
-        ) {
-            $next.get(0).classList.remove('clone');
-        }
-
         $repeat.remove();
-
-        this.form.features.repeatClone =
-            this.form.view.html.querySelector('.or-repeat.clone') != null;
 
         invalidateRepeatCaches(repeatPath);
 

--- a/src/js/required.js
+++ b/src/js/required.js
@@ -6,7 +6,32 @@
 
 import $ from 'jquery';
 
+/**
+ * @typedef {import('./form').Form} Form
+ */
+
 export default {
+    /**
+     * @type {Form}
+     */
+    // @ts-expect-error - this will be populated during form init, but assigning
+    // its type here improves intellisense.
+    form: null,
+
+    init() {
+        if (!this.form) {
+            throw new Error(
+                'Required module not correctly instantiated with form property.'
+            );
+        }
+
+        if (!this.form.features.required) {
+            this.update = () => {};
+        }
+
+        this.update();
+    },
+
     /**
      * Updates readonly
      *
@@ -17,16 +42,8 @@ export default {
         // A "required" update will never result in a node value change so the expression evaluation result can be cached fairly aggressively.
         const requiredCache = {};
 
-        if (!this.form) {
-            throw new Error(
-                'Required module not correctly instantiated with form property.'
-            );
-        }
-
         const $nodes = this.form.getRelatedNodes('data-required', '', updated);
-        const repeatClonesPresent =
-            this.form.repeatsPresent &&
-            this.form.view.html.querySelector('.or-repeat.clone');
+        const repeatClonesPresent = this.form.features.repeatClone;
 
         $nodes.each(function () {
             const $input = $(this);

--- a/src/js/required.js
+++ b/src/js/required.js
@@ -43,7 +43,6 @@ export default {
         const requiredCache = {};
 
         const $nodes = this.form.getRelatedNodes('data-required', '', updated);
-        const repeatClonesPresent = this.form.features.repeatClone;
 
         $nodes.each(function () {
             const $input = $(this);
@@ -51,9 +50,7 @@ export default {
             const requiredExpr = that.form.input.getRequired(input);
             const path = that.form.input.getName(input);
             // Minimize index determination because it is expensive.
-            const index = repeatClonesPresent
-                ? that.form.input.getIndex(input)
-                : 0;
+            const index = that.form.input.getIndex(input);
             // The path is stripped of the last nodeName to record the context.
             // This might be dangerous, but until we find a bug, it improves performance a lot in those forms where one group contains
             // many sibling questions that each have the same required expression.

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -15,6 +15,13 @@ class Widget {
     static globalInit(form, rootElement) {
         this.form = form;
         this.rootElement = rootElement;
+
+        if (form.features.relevant) {
+            this.implementsDisable =
+                this.prototype.disable !== Widget.prototype.disable;
+            this.implementsEnable =
+                this.prototype.enable !== Widget.prototype.enable;
+        }
     }
 
     static globalReset() {
@@ -22,6 +29,8 @@ class Widget {
 
         delete this.form;
         delete this.rootElement;
+        delete this.implementsDisable;
+        delete this.implementsEnable;
 
         return { form, rootElement };
     }
@@ -218,3 +227,7 @@ class Widget {
 }
 
 export default Widget;
+
+/**
+ * @typedef {(new (...args: any[]) => Widget & Pick<typeof Widget, keyof typeof Widget>)} WidgetClass
+ */

--- a/src/js/widgets-controller.js
+++ b/src/js/widgets-controller.js
@@ -206,6 +206,11 @@ const reset = () => {
     widgetsImplementingEnable = new Set();
 };
 
+/** @type {Map<typeof Widget, Set<HTMLElement>>} */
+const languageChangeUpdates = new Map();
+
+let didSetLanguageChangeListener = false;
+
 /**
  * Calls widget('update') when the language changes. This function is called upon initialization,
  * and whenever a new repeat is created. In the latter case, since the widget('update') is called upon
@@ -217,9 +222,26 @@ const reset = () => {
 function _setLangChangeListener(Widget, els) {
     // call update for all widgets when language changes
     if (els.length > 0) {
-        formElement.addEventListener(events.ChangeLanguage().type, () => {
-            new Collection(els).update(Widget);
+        let all = languageChangeUpdates.get(Widget);
+
+        if (all == null) {
+            all = new Set();
+            languageChangeUpdates.set(Widget, all);
+        }
+
+        els.forEach((el) => {
+            all.add(el);
         });
+
+        if (!didSetLanguageChangeListener) {
+            formElement.addEventListener(events.ChangeLanguage().type, () => {
+                for (const [Widget, els] of languageChangeUpdates) {
+                    new Collection([...els]).update(Widget);
+                }
+            });
+
+            didSetLanguageChangeListener = true;
+        }
     }
 }
 

--- a/src/widget/time/timepicker.js
+++ b/src/widget/time/timepicker.js
@@ -426,17 +426,6 @@ import { time } from '../../js/format';
                 return;
             }
 
-            this.$element.trigger({
-                type: 'hide.timepicker',
-                time: {
-                    value: this.getTime(),
-                    hours: this.hour,
-                    minutes: this.minute,
-                    seconds: this.second,
-                    meridian: this.meridian,
-                },
-            });
-
             this.$widget.removeClass('open');
 
             $(document).off(
@@ -1075,17 +1064,6 @@ import { time } from '../../js/format';
                 this.handleDocumentClick
             );
 
-            this.$element.trigger({
-                type: 'show.timepicker',
-                time: {
-                    value: this.getTime(),
-                    hours: this.hour,
-                    minutes: this.minute,
-                    seconds: this.second,
-                    meridian: this.meridian,
-                },
-            });
-
             this.place();
             if (this.disableFocus) {
                 this.$element.blur();
@@ -1116,17 +1094,6 @@ import { time } from '../../js/format';
             if (!ignoreWidget) {
                 this.updateWidget();
             }
-
-            this.$element.trigger({
-                type: 'changeTime.timepicker',
-                time: {
-                    value: this.getTime(),
-                    hours: this.hour,
-                    minutes: this.minute,
-                    seconds: this.second,
-                    meridian: this.meridian,
-                },
-            });
         },
 
         updateElement() {

--- a/test/forms/collections.xml
+++ b/test/forms/collections.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+    xmlns:OpenClinica="http://openclinica.com/odm"
+    xmlns:enk="http://enketo.org/xforms"
+    xmlns:ev="http://www.w3.org/2001/xml-events"
+    xmlns:h="http://www.w3.org/1999/xhtml"
+    xmlns:jr="http://openrosa.org/javarosa"
+    xmlns:oc="http://openclinica.org/xforms"
+    xmlns:odk="http://www.opendatakit.org/xforms"
+    xmlns:orx="http://openrosa.org/xforms"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <h:head>
+        <h:title>collections</h:title>
+        <model odk:xforms-version="1.0.0">
+            <instance>
+                <data id="collections">
+                    <initial-default>initial default</initial-default>
+                    <first-load />
+                    <rep jr:template="">
+                        <rep-first-load />
+                        <new-rep />
+                        <rep-val />
+                        <rep-val-changed />
+
+                        <rep2 jr:template="">
+                            <rep2-input />
+                        </rep2>
+                    </rep>
+                    <rep>
+                        <rep-first-load />
+                        <new-rep />
+                        <rep-val />
+                        <rep-val-changed />
+
+                        <rep2>
+                            <rep2-input />
+                        </rep2>
+                    </rep>
+
+                    <val />
+                    <val-changed />
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <bind nodeset="/data/initial-default" type="string"/>
+            <bind nodeset="/data/first-load" type="string"/>
+            <bind nodeset="/data/rep/rep-first-load" type="string"/>
+            <bind nodeset="/data/rep/new-rep" type="string"/>
+            <bind nodeset="/data/rep/rep-val" type="int"/>
+            <bind nodeset="/data/rep/rep-val-changed" type="string"/>
+            <bind nodeset="/data/val" type="int"/>
+            <bind nodeset="/data/val-changed" type="string"/>
+            <bind nodeset="/data/rep/rep2/rep2-input" type="int" calculate="position(..) * position(../..)" />
+            <bind jr:preload="uid" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+            <setvalue event="odk-instance-first-load" ref="/data/first-load">1</setvalue>
+            <setvalue event="odk-instance-first-load" ref="/data/rep/rep-first-load" value="concat('first-load * position: ', ../../first-load * position(..))" />
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/initial-default">
+            <label>initial-default</label>
+        </input>
+
+        <group ref="/data/rep">
+            <label>rep</label>
+            <repeat nodeset="/data/rep">
+                <setvalue event="odk-new-repeat" ref="/data/rep/new-rep" value="concat('new repeat position * 2: ', position(..) * 2)" />
+
+                <input ref="/data/rep/rep-first-load">
+                    <label>rep-first-load</label>
+                </input>
+
+                <input ref="/data/rep/new-rep">
+                    <label>new-rep</label>
+                    <setvalue event="odk-instance-first-load" ref="/data/rep/new-rep" value="concat('first load position: ', position(..))" />
+                </input>
+
+                <input ref="/data/rep/rep-val">
+                    <label>rep-val</label>
+                    <setvalue event="xforms-value-changed" ref="/data/rep/rep-val-changed" value="concat('rep val changed: ', ../rep-val)" />
+                </input>
+
+                <input ref="/data/rep/rep-val-changed">
+                    <label>rep-val-changed</label>
+                </input>
+
+                <group ref="/data/rep/rep2">
+                    <label>rep</label>
+                    <repeat nodeset="/data/rep/rep2">
+                        <input ref="/data/rep/rep2/rep2-input">
+                            <label>rep/rep-2</label>
+                        </input>
+                    </repeat>
+                </group>
+            </repeat>
+        </group>
+
+        <input ref="/data/val">
+            <label>val</label>
+            <setvalue event="xforms-value-changed" ref="/data/val-changed" value="concat('val changed: ', /data/val)" />
+        </input>
+
+        <input ref="/data/val-changed">
+            <label>val-changed</label>
+        </input>
+    </h:body>
+</h:html>

--- a/test/spec/calculate.spec.js
+++ b/test/spec/calculate.spec.js
@@ -41,6 +41,10 @@ describe('calculate functionality', () => {
 
         form.init();
 
+        form.view.html.addEventListener(events.Change().type, () => {
+            timers.tick(1);
+        });
+
         const firstInput = form.view.html.querySelector(
             'input[name="/calcs-cascade/first"]'
         );
@@ -240,11 +244,11 @@ describe('calculate functionality', () => {
             const form = loadForm('relevant-calcs.xml', null);
 
             form.init();
-            timers.runAll();
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const grp = form.model.xml.querySelector('grp');
-
-            timers.runAll();
 
             expect(grp.textContent.replace(/\s/g, '')).to.equal('');
 
@@ -253,16 +257,12 @@ describe('calculate functionality', () => {
             a.value = 'a';
             a.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(grp.textContent.replace(/\s/g, '')).to.equal(
                 'onetwothreefour'
             );
 
             a.value = '';
             a.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(grp.textContent.replace(/\s/g, '')).to.equal('');
         });
@@ -271,11 +271,12 @@ describe('calculate functionality', () => {
             const form = loadForm('relevant-calcs.xml', null);
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const grp = form.model.xml.querySelector('grp');
-
-            timers.runAll();
 
             expect(grp.textContent.replace(/\s/g, '')).to.equal('');
 
@@ -284,8 +285,6 @@ describe('calculate functionality', () => {
             a.value = 'a';
             a.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(grp.textContent.replace(/\s/g, '')).to.equal(
                 'onetwothreefour'
             );
@@ -293,12 +292,8 @@ describe('calculate functionality', () => {
             a.value = '';
             a.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             a.value = 'a';
             a.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(grp.textContent.replace(/\s/g, '')).to.equal(
                 'onetwothreefour'
@@ -309,11 +304,12 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const child = form.model.xml.querySelector('is-child-relevant');
-
-            timers.runAll();
 
             expect(child.textContent).to.equal('');
 
@@ -327,19 +323,13 @@ describe('calculate functionality', () => {
             setsGroupRelevance.value = '1';
             setsGroupRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             setsChildRelevance.value = '2';
             setsChildRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(child.textContent).to.equal('is relevant');
 
             setsGroupRelevance.value = '';
             setsGroupRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(child.textContent).to.equal('');
         });
@@ -348,11 +338,12 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const child = form.model.xml.querySelector('is-child-relevant');
-
-            timers.runAll();
 
             expect(child.textContent).to.equal('');
 
@@ -366,24 +357,16 @@ describe('calculate functionality', () => {
             setsGroupRelevance.value = '1';
             setsGroupRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             setsChildRelevance.value = '2';
             setsChildRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(child.textContent).to.equal('is relevant');
 
             setsGroupRelevance.value = '';
             setsGroupRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             setsGroupRelevance.value = '1';
             setsGroupRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(child.textContent).to.equal('is relevant');
         });
@@ -393,11 +376,11 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
 
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
             const now = form.model.xml.querySelector('now');
-
-            timers.runAll();
 
             const initialValue = new Date(now.textContent).getTime();
 
@@ -410,12 +393,8 @@ describe('calculate functionality', () => {
             toggleNow.value = '';
             toggleNow.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             toggleNow.value = '1';
             toggleNow.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             const recalculatedValue = new Date(now.textContent).getTime();
 
@@ -426,11 +405,11 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
 
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
             const now = form.model.xml.querySelector('now-grouped now');
-
-            timers.runAll();
 
             const initialValue = new Date(now.textContent).getTime();
 
@@ -443,12 +422,8 @@ describe('calculate functionality', () => {
             toggleNow.value = '';
             toggleNow.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             toggleNow.value = '1';
             toggleNow.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             const recalculatedValue = new Date(now.textContent).getTime();
 
@@ -459,12 +434,12 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
 
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
             const computedByChild =
                 form.model.xml.querySelector('computed-by-child');
-
-            timers.runAll();
 
             const initialValue = computedByChild.textContent;
 
@@ -480,26 +455,18 @@ describe('calculate functionality', () => {
             setsGroupRelevance.value = '1';
             setsGroupRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             setsChildRelevance.value = '2';
             setsChildRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(computedByChild.textContent).to.equal('is relevant');
 
             setsChildRelevance.value = '';
             setsChildRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(computedByChild.textContent).to.equal('');
 
             setsChildRelevance.value = '2';
             setsChildRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(computedByChild.textContent).to.equal('is relevant');
         });
@@ -508,12 +475,13 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const assignAnyValue =
                 form.model.xml.querySelector('assign-any-value');
-
-            timers.runAll();
 
             const initialValue = assignAnyValue.textContent;
 
@@ -526,8 +494,6 @@ describe('calculate functionality', () => {
             setsRelevance.value = '1';
             setsRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             const assignAnyValueInput = form.view.html.querySelector(
                 'input[name="/data/assign-any-value"]'
             );
@@ -535,21 +501,15 @@ describe('calculate functionality', () => {
             assignAnyValueInput.value = 'any value';
             assignAnyValueInput.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(assignAnyValue.textContent).to.equal('any value');
 
             setsRelevance.value = '';
             setsRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(assignAnyValue.textContent).to.equal('');
 
             setsRelevance.value = '1';
             setsRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(assignAnyValue.textContent).to.equal('any value');
         });
@@ -558,12 +518,13 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const assignAnyValue =
                 form.model.xml.querySelector('assign-any-value');
-
-            timers.runAll();
 
             const initialValue = assignAnyValue.textContent;
 
@@ -577,14 +538,10 @@ describe('calculate functionality', () => {
                 'input[name="/data/calc-by-assign-any-value"]'
             );
 
-            timers.runAll();
-
             expect(calculated.value).to.equal('');
 
             setsRelevance.value = '1';
             setsRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             const assignAnyValueInput = form.view.html.querySelector(
                 'input[name="/data/assign-any-value"]'
@@ -593,21 +550,15 @@ describe('calculate functionality', () => {
             assignAnyValueInput.value = 'any value';
             assignAnyValueInput.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(calculated.value).to.equal('any value');
 
             setsRelevance.value = '';
             setsRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(calculated.value).to.equal('');
 
             setsRelevance.value = '1';
             setsRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(calculated.value).to.equal('any value');
         });
@@ -616,7 +567,10 @@ describe('calculate functionality', () => {
             const form = loadForm('exclude-non-relevant-basic.xml', null);
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const outerGroup = form.model.xml.querySelector(
                 'is-outer-group-relevant'
@@ -627,8 +581,6 @@ describe('calculate functionality', () => {
             const child = form.model.xml.querySelector(
                 'child-without-direct-relevant-expression'
             );
-
-            timers.runAll();
 
             expect(outerGroup.textContent.trim()).to.equal('');
             expect(innerGroup.textContent.trim()).to.equal('');
@@ -641,8 +593,6 @@ describe('calculate functionality', () => {
             setsOuterRelevance.value = 'yes';
             setsOuterRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(outerGroup.textContent.trim()).to.equal('');
             expect(innerGroup.textContent.trim()).to.equal('');
             expect(child.textContent).to.equal('');
@@ -654,16 +604,12 @@ describe('calculate functionality', () => {
             setsInnerRelevance.value = 'yes';
             setsInnerRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(outerGroup.textContent.trim()).to.equal('yes');
             expect(innerGroup.textContent.trim()).to.equal('yes');
             expect(child.textContent).to.equal('yes');
 
             setsInnerRelevance.value = 'no';
             setsInnerRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(outerGroup.textContent.trim()).to.equal('');
             expect(innerGroup.textContent.trim()).to.equal('');
@@ -672,16 +618,12 @@ describe('calculate functionality', () => {
             setsInnerRelevance.value = 'yes';
             setsInnerRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(outerGroup.textContent.trim()).to.equal('yes');
             expect(innerGroup.textContent.trim()).to.equal('yes');
             expect(child.textContent).to.equal('yes');
 
             setsOuterRelevance.value = 'no';
             setsOuterRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(outerGroup.textContent.trim()).to.equal('');
             expect(innerGroup.textContent.trim()).to.equal('');
@@ -690,8 +632,6 @@ describe('calculate functionality', () => {
             setsOuterRelevance.value = 'yes';
             setsOuterRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(outerGroup.textContent.trim()).to.equal('yes');
             expect(innerGroup.textContent.trim()).to.equal('yes');
             expect(child.textContent).to.equal('yes');
@@ -699,16 +639,12 @@ describe('calculate functionality', () => {
             setsOuterRelevance.value = 'no';
             setsOuterRelevance.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(outerGroup.textContent.trim()).to.equal('');
             expect(innerGroup.textContent.trim()).to.equal('');
             expect(child.textContent).to.equal('');
 
             setsOuterRelevance.value = 'yes';
             setsOuterRelevance.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(outerGroup.textContent.trim()).to.equal('yes');
             expect(innerGroup.textContent.trim()).to.equal('yes');
@@ -719,7 +655,10 @@ describe('calculate functionality', () => {
             const form = loadForm('recalculations.xml');
 
             form.init();
-            timers.runAll();
+
+            form.view.html.addEventListener(events.Change().type, () => {
+                timers.tick(1);
+            });
 
             const q1 = form.view.html.querySelector(
                 'input[name="/recalculations/q1"]'
@@ -734,21 +673,15 @@ describe('calculate functionality', () => {
             q1.value = '1';
             q1.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             expect(q2.value).to.equal('7');
 
             q2.value = '8';
             q3.dispatchEvent(events.Change());
 
-            timers.runAll();
-
             const calculationUpdateSpy = sandbox.spy(form.calc, '_updateCalc');
 
             q3.value = '1';
             q3.dispatchEvent(events.Change());
-
-            timers.runAll();
 
             expect(calculationUpdateSpy).not.to.have.been.calledWith(q2);
             expect(q2.value).to.equal('8');

--- a/test/spec/dom/collections.spec.js
+++ b/test/spec/dom/collections.spec.js
@@ -1,0 +1,229 @@
+// @ts-check
+
+import { RefIndexedDOMCollection } from '../../../src/js/dom/collections';
+
+import loadForm from '../../helpers/load-form';
+
+/**
+ * @typedef {import('../../../src/js/form').Form} Form
+ */
+
+describe('DOM collections', () => {
+    describe('indexed by reference', () => {
+        /** @type {Form} */
+        let form;
+
+        /** @type {HTMLFormElement} */
+        let formElement;
+
+        /** @type {RefIndexedDOMCollection} */
+        let collection;
+
+        const selector = '.arbitrary-even, .arbitrary-odd';
+
+        beforeEach(() => {
+            form = loadForm('collections.xml');
+            formElement = form.view.html;
+
+            const repeatInstances = formElement.querySelectorAll('.or-repeat');
+
+            repeatInstances.forEach((repeatInstance, index) => {
+                repeatInstance.insertAdjacentHTML(
+                    'afterbegin',
+                    /* html */ `
+                    <span class="arbitrary-${
+                        index % 2 === 0 ? 'even' : 'odd'
+                    }" data-arbitrary-ref="${repeatInstance.getAttribute(
+                        'name'
+                    )}/child"></span>
+                `
+                );
+            });
+
+            collection = new RefIndexedDOMCollection(
+                'arbitrary-collection',
+                form,
+                formElement,
+                selector,
+                'data-arbitrary-ref'
+            );
+
+            form.init();
+        });
+
+        afterEach(() => {
+            form.resetView();
+
+            expect(collection.hasRef('/data/rep/child')).to.be.false;
+            expect(collection.hasRef('/data/rep/rep2/child')).to.be.false;
+            expect(collection.getElements().length).to.equal(0);
+        });
+
+        it('gets all elements matching the specified selector', () => {
+            const elements = collection.getElements();
+
+            expect(elements.length).to.equal(2);
+
+            expect(elements).to.deep.equal([
+                ...formElement.querySelectorAll(selector),
+            ]);
+        });
+
+        it('gets an updated list of all matching elements after a repeat instance is added', () => {
+            const addOuterRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat-info[data-name="/data/rep"] .add-repeat-btn'
+                )
+            );
+
+            addOuterRepeatButton?.click();
+
+            let elements = collection.getElements();
+
+            expect(elements.length).to.equal(4);
+
+            expect(elements).to.deep.equal([
+                ...formElement.querySelectorAll(selector),
+            ]);
+
+            const addInnerRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat[name="/data/rep"]:nth-of-type(2) .or-repeat-info[data-name="/data/rep/rep2"] .add-repeat-btn'
+                )
+            );
+
+            addInnerRepeatButton?.click();
+
+            elements = collection.getElements();
+
+            expect(elements.length).to.equal(5);
+            expect(elements).to.deep.equal([
+                ...formElement.querySelectorAll(selector),
+            ]);
+        });
+
+        it('gets all elements matching the specified selector and reference', () => {
+            const elements = collection.getElementsByRef(
+                '/data/rep/rep2/child'
+            );
+
+            expect(elements.length).to.equal(1);
+
+            expect(elements).to.deep.equal([
+                ...formElement.querySelectorAll(
+                    '[data-arbitrary-ref="/data/rep/rep2/child"]'
+                ),
+            ]);
+        });
+
+        it('gets an updated list of all matching elements by reference after a repeat instance is added', () => {
+            const addOuterRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat-info[data-name="/data/rep"] .add-repeat-btn'
+                )
+            );
+
+            addOuterRepeatButton?.click();
+
+            let outer = collection.getElementsByRef('/data/rep/child');
+            let inner = collection.getElementsByRef('/data/rep/rep2/child');
+
+            expect(outer.length).to.equal(2);
+            expect(outer).to.deep.equal([
+                ...formElement.querySelectorAll(
+                    '[data-arbitrary-ref="/data/rep/child"]'
+                ),
+            ]);
+            expect(inner.length).to.equal(2);
+            expect(inner).to.deep.equal([
+                ...formElement.querySelectorAll(
+                    '[data-arbitrary-ref="/data/rep/rep2/child"]'
+                ),
+            ]);
+
+            const addInnerRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat[name="/data/rep"]:nth-of-type(2) .or-repeat-info[data-name="/data/rep/rep2"] .add-repeat-btn'
+                )
+            );
+
+            addInnerRepeatButton?.click();
+
+            outer = collection.getElementsByRef('/data/rep/child');
+            inner = collection.getElementsByRef('/data/rep/rep2/child');
+
+            expect(outer.length).to.equal(2);
+            expect(outer).to.deep.equal([
+                ...formElement.querySelectorAll(
+                    '[data-arbitrary-ref="/data/rep/child"]'
+                ),
+            ]);
+            expect(inner.length).to.equal(3);
+            expect(inner).to.deep.equal([
+                ...formElement.querySelectorAll(
+                    '[data-arbitrary-ref="/data/rep/rep2/child"]'
+                ),
+            ]);
+        });
+
+        it('gets the index of matching elements by reference', () => {
+            const addOuterRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat-info[data-name="/data/rep"] .add-repeat-btn'
+                )
+            );
+
+            addOuterRepeatButton?.click();
+
+            const addInnerRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat[name="/data/rep"]:nth-of-type(2) .or-repeat-info[data-name="/data/rep/rep2"] .add-repeat-btn'
+                )
+            );
+
+            addInnerRepeatButton?.click();
+
+            ['/data/rep/child', '/data/rep/rep2/child'].forEach((ref) => {
+                const elements = collection.getElementsByRef(ref);
+
+                elements.forEach((element, index) => {
+                    expect(collection.refIndexOf(element, ref)).to.equal(index);
+                });
+            });
+        });
+
+        it('gets the element by reference at the specified index', () => {
+            const addOuterRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat-info[data-name="/data/rep"] .add-repeat-btn'
+                )
+            );
+
+            addOuterRepeatButton?.click();
+
+            const addInnerRepeatButton = /** @type {HTMLElement} */ (
+                formElement.querySelector(
+                    '.or-repeat[name="/data/rep"]:nth-of-type(2) .or-repeat-info[data-name="/data/rep/rep2"] .add-repeat-btn'
+                )
+            );
+
+            addInnerRepeatButton?.click();
+
+            ['/data/rep/child', '/data/rep/rep2/child'].forEach((ref) => {
+                const elements = collection.getElementsByRef(ref);
+
+                elements.forEach((element, index) => {
+                    expect(collection.getElementByRef(ref, index)).to.equal(
+                        element
+                    );
+                });
+            });
+        });
+
+        it('determines whether a specified ref is present', () => {
+            expect(collection.hasRef('/data/rep/child')).to.be.true;
+            expect(collection.hasRef('/data/rep/rep2/child')).to.be.true;
+            expect(collection.hasRef('/data/rep/rep2/rep3/child')).to.be.false;
+        });
+    });
+});

--- a/test/spec/dom/tree-walker.spec.js
+++ b/test/spec/dom/tree-walker.spec.js
@@ -50,7 +50,7 @@ describe('DOM tree walker functionality', () => {
                                     </section>
 
                                     <section
-                                        class="or-repeat clone"
+                                        class="or-repeat"
                                         name="/data/foo/bar"
                                         id="repeat-foo-0-bar-1">
                                         <!--repeats:/data/foo/bar-->
@@ -72,7 +72,7 @@ describe('DOM tree walker functionality', () => {
                             </section>
 
                             <section
-                                class="or-repeat clone"
+                                class="or-repeat"
                                 name="/data/foo"
                                 id="repeat-foo-1">
                                 <!--repeats:/data/foo-->
@@ -97,7 +97,7 @@ describe('DOM tree walker functionality', () => {
                                     </section>
 
                                     <section
-                                        class="or-repeat clone"
+                                        class="or-repeat"
                                         name="/data/foo/bar"
                                         id="repeat-foo-1-bar-1">
                                         <!--repeats:/data/foo/bar-->

--- a/test/spec/dom/tree-walker.spec.js
+++ b/test/spec/dom/tree-walker.spec.js
@@ -1,0 +1,276 @@
+// @ts-check
+
+import {
+    findMarkerComment,
+    findMarkerComments,
+} from '../../../src/js/dom/tree-walker';
+
+describe('DOM tree walker functionality', () => {
+    describe('Comment markers', () => {
+        /** @type {HTMLFormElement} */
+        let formElement;
+
+        beforeEach(() => {
+            const range = document.createRange();
+
+            // This is a pared down representation of a real form's current DOM
+            // structure, with IDs added for test clarity/simplicity.
+            const { firstElementChild } =
+                range.createContextualFragment(/* html */ `
+                    <form class="or">
+                        <section
+                            class="or-group-data"
+                            name="/data/foo"
+                            id="group-foo">
+                            <!--groups:/data/foo-->
+
+                            <section
+                                class="or-repeat"
+                                name="/data/foo"
+                                id="repeat-foo-0">
+                                <!--repeats:/data/foo-->
+
+                                <section
+                                    class="or-group"
+                                    name="/data/foo/bar"
+                                    id="group-foo-0-bar">
+                                    <!--groups:/data/foo/bar-->
+
+                                    <h4>
+                                        <span class="question-label active">Foo Bar</span>
+                                    </h4>
+
+                                    <section
+                                        class="or-repeat"
+                                        name="/data/foo/bar"
+                                        id="repeat-foo-0-bar-0">
+                                        <!--repeats:/data/foo/bar-->
+
+                                        <input type="text" name="/data/foo/bar/q1" data-type-xml="string">
+                                    </section>
+
+                                    <section
+                                        class="or-repeat clone"
+                                        name="/data/foo/bar"
+                                        id="repeat-foo-0-bar-1">
+                                        <!--repeats:/data/foo/bar-->
+
+                                        <input type="text" name="/data/foo/bar/q1" data-type-xml="string">
+                                    </section>
+
+                                    <div
+                                        class="or-repeat-info"
+                                        data-name="/data/foo/bar"
+                                        id="repeat-info-foo-0-bar">
+                                        <!--repeatInfos:/data/foo/bar-->
+
+                                        <button type="button" class="btn btn-default add-repeat-btn">
+                                            <i class="icon icon-plus"></i>
+                                        </button>
+                                    </div>
+                                </section>
+                            </section>
+
+                            <section
+                                class="or-repeat clone"
+                                name="/data/foo"
+                                id="repeat-foo-1">
+                                <!--repeats:/data/foo-->
+
+                                <section
+                                    class="or-group"
+                                    name="/data/foo/bar"
+                                    id="group-foo-1-bar">
+                                    <!--groups:/data/foo/bar-->
+
+                                    <h4>
+                                        <span class="question-label active">Foo Bar</span>
+                                    </h4>
+
+                                    <section
+                                        class="or-repeat"
+                                        name="/data/foo/bar"
+                                        id="repeat-foo-1-bar-0">
+                                        <!--repeats:/data/foo/bar-->
+
+                                        <input type="text" name="/data/foo/bar/q1" data-type-xml="string">
+                                    </section>
+
+                                    <section
+                                        class="or-repeat clone"
+                                        name="/data/foo/bar"
+                                        id="repeat-foo-1-bar-1">
+                                        <!--repeats:/data/foo/bar-->
+
+                                        <input type="text" name="/data/foo/bar/q1" data-type-xml="string">
+                                    </section>
+
+                                    <div
+                                        class="or-repeat-info"
+                                        data-name="/data/foo/bar"
+                                        id="repeat-info-foo-1-bar">
+                                        <!--repeatInfos:/data/foo/bar-->
+
+                                        <button type="button" class="btn btn-default add-repeat-btn">
+                                            <i class="icon icon-plus"></i>
+                                        </button>
+                                    </div>
+                                </section>
+                            </section>
+                        </section>
+                    </form>
+                `);
+
+            formElement = /** @type {HTMLFormElement} */ (firstElementChild);
+        });
+
+        const commentCollectionCases = [
+            {
+                comparison: 'equals',
+                predicateValue: 'repeats:/data/foo/bar',
+                expectedParentIds: [
+                    'repeat-foo-0-bar-0',
+                    'repeat-foo-0-bar-1',
+                    'repeat-foo-1-bar-0',
+                    'repeat-foo-1-bar-1',
+                ],
+            },
+
+            {
+                startElementSelector: '#group-foo-1-bar',
+                comparison: 'equals',
+                predicateValue: 'repeats:/data/foo/bar',
+                expectedParentIds: ['repeat-foo-1-bar-0', 'repeat-foo-1-bar-1'],
+            },
+
+            {
+                comparison: 'starts with',
+                predicateValue: 'groups:',
+                expectedParentIds: [
+                    'group-foo',
+                    'group-foo-0-bar',
+                    'group-foo-1-bar',
+                ],
+            },
+        ];
+
+        commentCollectionCases.forEach(
+            ({
+                startElementSelector = 'form.or',
+                comparison,
+                predicateValue,
+                expectedParentIds,
+            }) => {
+                const descriptionParentIds = expectedParentIds
+                    .map((id) => `${id}`)
+                    .join(', ');
+
+                it(`finds all comments within or after ${startElementSelector} whose value ${comparison} ${predicateValue} in parents ${descriptionParentIds}`, () => {
+                    const startElement = /** @type {HTMLElement} */ (
+                        formElement.querySelector(startElementSelector) ??
+                            formElement.closest(startElementSelector)
+                    );
+
+                    const comments = findMarkerComments(
+                        formElement,
+                        (commentValue) => {
+                            switch (comparison) {
+                                case 'equals':
+                                    return commentValue === predicateValue;
+
+                                case 'starts with':
+                                    return commentValue.startsWith(
+                                        predicateValue
+                                    );
+
+                                default:
+                                    return false;
+                            }
+                        },
+                        { startElement }
+                    );
+
+                    const parentIds = comments.map(
+                        ({ parentElement }) => parentElement?.id
+                    );
+
+                    expect(parentIds).to.deep.equal(expectedParentIds);
+                });
+            }
+        );
+
+        const indexedCommentCases = [
+            {
+                commentValue: 'groups:/data/foo',
+                index: 0,
+                expectedParentId: 'group-foo',
+            },
+            {
+                commentValue: 'groups:/data/foo/bar',
+                index: 0,
+                expectedParentId: 'group-foo-0-bar',
+            },
+            {
+                commentValue: 'groups:/data/foo/bar',
+                index: 1,
+                expectedParentId: 'group-foo-1-bar',
+            },
+            {
+                commentValue: 'repeats:/data/foo',
+                index: 1,
+                expectedParentId: 'repeat-foo-1',
+            },
+            {
+                commentValue: 'repeats:/data/foo',
+                index: 0,
+                expectedParentId: 'repeat-foo-0',
+            },
+            {
+                commentValue: 'repeats:/data/foo/bar',
+                index: 3,
+                expectedParentId: 'repeat-foo-1-bar-1',
+            },
+            {
+                commentValue: 'repeats:/data/foo/bar',
+                index: 2,
+                expectedParentId: 'repeat-foo-1-bar-0',
+            },
+            {
+                commentValue: 'repeatInfos:/data/foo/bar',
+                index: 1,
+                expectedParentId: 'repeat-info-foo-1-bar',
+            },
+            {
+                commentValue: 'repeatInfos:/data/foo/bar',
+                index: 0,
+                expectedParentId: 'repeat-info-foo-0-bar',
+            },
+        ];
+
+        indexedCommentCases.forEach(
+            ({ commentValue, index, expectedParentId }) => {
+                it(`finds comment <!--${commentValue}--> within parent #${expectedParentId}`, () => {
+                    const comment = findMarkerComment(
+                        formElement,
+                        commentValue,
+                        index
+                    );
+
+                    if (comment == null) {
+                        throw new Error('Expected to find a comment');
+                    }
+
+                    expect(comment.data).to.equal(commentValue);
+
+                    const { parentElement } = comment;
+
+                    if (parentElement == null) {
+                        throw new Error('Expected to find a parent element');
+                    }
+
+                    expect(parentElement.id).to.equal(expectedParentId);
+                });
+            }
+        );
+    });
+});

--- a/test/spec/input.spec.js
+++ b/test/spec/input.spec.js
@@ -1,15 +1,21 @@
 import loadForm from '../helpers/load-form';
 
+/**
+ * @typedef {import('../../src/js/form').Form} Form
+ */
+
 describe('input helper', () => {
     describe('getIndex() function', () => {
-        const form = loadForm('nested_repeats.xml');
-        form.init();
-        const inputEls = form.view.html.querySelectorAll(
-            '[name="/nested_repeats/kids/kids_details/immunization_info/vaccine"]'
-        );
+        it('works with nested repeats to get the index of a question in respect to the whole form', () => {
+            const form = loadForm('nested_repeats.xml');
 
-        [0, 1, 2, 3, 4].forEach((index) => {
-            it('works with nested repeats to get the index of a question in respect to the whole form', () => {
+            form.init();
+
+            const inputEls = form.view.html.querySelectorAll(
+                '[name="/nested_repeats/kids/kids_details/immunization_info/vaccine"]'
+            );
+
+            [0, 1, 2, 3, 4].forEach((index) => {
                 expect(form.input.getIndex(inputEls[index])).to.equal(index);
             });
         });
@@ -32,12 +38,14 @@ describe('input helper', () => {
     });
 
     describe('clear() function', () => {
-        const form = loadForm('repeat-default.xml');
-        form.init();
-        const num = form.view.html.querySelector('[name="/repdef/rep/num"]');
-        const grp = form.view.html.querySelector('[name="/repdef/rep"]');
-
         it('works for groups of control', () => {
+            const form = loadForm('repeat-default.xml');
+            form.init();
+            const num = form.view.html.querySelector(
+                '[name="/repdef/rep/num"]'
+            );
+            const grp = form.view.html.querySelector('[name="/repdef/rep"]');
+
             expect(num.value).to.equal('5');
 
             form.input.clear(grp);

--- a/test/spec/itemset.spec.js
+++ b/test/spec/itemset.spec.js
@@ -892,28 +892,28 @@ describe('Itemset functionality', () => {
 
     // Radiobutton itemset set cache problem: https://github.com/OpenClinica/enketo-express-oc/issues/423
     describe('in a repeat with a simple nodeset query, and defaults for multiple repeats', () => {
-        const form = loadForm(
-            'repeat-radio-itemset.xml',
-            `
-        <data>
-            <rep>
-                <sel>fair</sel>
-            </rep>
-            <rep>
-                <sel>bad</sel>
-            </rep>
-            <rep>
-                <sel>good</sel>
-            </rep>
-            <meta>
-                <instanceID>uuid:1234</instanceID>
-            </meta>
-        </data>
-        `
-        );
-        form.init();
-
         it('sets all radiobuttons correctly', () => {
+            const form = loadForm(
+                'repeat-radio-itemset.xml',
+                `
+                    <data>
+                        <rep>
+                            <sel>fair</sel>
+                        </rep>
+                        <rep>
+                            <sel>bad</sel>
+                        </rep>
+                        <rep>
+                            <sel>good</sel>
+                        </rep>
+                        <meta>
+                            <instanceID>uuid:1234</instanceID>
+                        </meta>
+                    </data>
+                `
+            );
+            form.init();
+
             const checkeds = [
                 ...form.view.html.querySelectorAll(
                     '.option-wrapper input:checked:not(.itemset-template)'

--- a/test/spec/itemset.spec.js
+++ b/test/spec/itemset.spec.js
@@ -405,7 +405,7 @@ describe('Itemset functionality', () => {
                 .trigger('change');
             // add repeat
             form.view.$.find('.add-repeat-btn').click();
-            $clonedRepeat = form.view.$.find('.or-repeat.clone');
+            $clonedRepeat = form.view.$.find('.or-repeat + .or-repeat');
         });
 
         it('the itemset of the cloned repeat is correct (and not a cloned copy of the master repeat)', () => {
@@ -569,7 +569,7 @@ describe('Itemset functionality', () => {
             // second option
             form.view.html.querySelector('.add-repeat-btn').click();
             const input2 = form.view.html.querySelector(
-                '.clone [name="/data/repeat1/specimen_id"]'
+                '.or-repeat + .or-repeat [name="/data/repeat1/specimen_id"]'
             );
             input2.value = 'bb';
             input2.dispatchEvent(events.Change());

--- a/test/spec/repeat.spec.js
+++ b/test/spec/repeat.spec.js
@@ -1107,7 +1107,7 @@ describe('repeat functionality', () => {
             setRepeatRelevant.dispatchEvent(event.Change());
 
             const setSecondNumberNonRelevant = form.view.html.querySelector(
-                '.or-repeat.clone [data-name="/data/rep/is-num-relevant"][value="no"]'
+                '.or-repeat + .or-repeat [data-name="/data/rep/is-num-relevant"][value="no"]'
             );
 
             setSecondNumberNonRelevant.checked = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "experimentalDecorators": true,
         "forceConsistentCasingInFileNames": true,
         "inlineSourceMap": true,
-        "lib": ["dom", "ES2018"],
+        "lib": ["DOM", "DOM.Iterable", "ES2018"],
         "module": "esnext",
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
@@ -26,6 +26,6 @@
             "enketo/config": ["./config.js"]
         }
     },
-    "exclude": ["node_modules"],
-    "include": ["src", "test", "typings"]
+    "exclude": ["./node_modules/*", "./test-coverage/*"],
+    "include": ["./src/*.js", "./test/*.js"]
 }


### PR DESCRIPTION
While there are a variety of changes in this PR, they all follow a common theme (as the title suggests): do less redundant work, specifically DOM work. All of the changes target code which:

- contribute significantly to many forms with clear optimization potential, as identified profiling those forms
- are either static in nature, or have clearly generalizable dynamic patterns
- have reasonably clear potential for caching, or can be statically identified as no-ops for a given form

The improvements are particularly pronounced on for forms with complex behavior around repeats. But highly complex forms **without** repeats may also benefit significantly from the caching portions of the changes.

## Highlights

The commit notes hopefully cover some of the more mundane and smaller changes, but I do want to go into more detail about some new concepts and abstractions this PR introduce.

### Preprocessing model references

In this change, before a form is initialized, the view DOM is queried to identify certain elements which reference model nodesets, and to annotate those elements and some of their containers with classes which allow simpler queries during init and form entry.

In some cases this allowed certain dynamic DOM queries to be made static. This is itself a common theme across many of Enketo Core's performance challenges. While querying the DOM _in general_ can perform very well, performance degrades significantly when the queries themselves are dynamically composed, particularly when this is done repeatedly.

### Identifying form-wide characteristics

After the aforementioned preprocessing, a form's view DOM is then analyzed to determine whether certain types of functionality are ever used by the form. This analysis is then used to short-circuit whole portions of app behavior which are known to be no-ops but have a significant performance impact nonetheless.

### Static and semi-static DOM collections

This change introduces a new abstraction/class, `RefIndexedDOMCollection` (I am not married to this name! bikeshed away), which generalizes some functionality around form features which:

- Have an identifiable role/type
- Are transformed by Enketo Transformer to have a known attribute name whose value is a stable model nodeset reference, where existing form logic is concerned with:
  - finding elements of a given role by a given reference
  - identifying the presence of said reference in a form, or in another element's hierarchy
- Are indexed by their [containing] repeat instance on forms with repeats, where existing form logic is concerned with:
  - determining their current index position
  - finding an element with a given role/reference at a specified index position

In the current set of changes, the following roles/types use some or all of the above functionality:

- actions and other model references (preprocessed as described above), as well as some of their containers
- groups
- repeats and "repeatInfos" (footer elements for each run of repeat instances, which also display the add button for user-controlled repeats and may contain additional metadata or templates used by individual repeat instances)

This abstraction accounts for a very large portion of the performance improvements herein, in no small part to specific implementation details:

- Again, prior to other existing form initializtion logic, the view DOM is annotated to optimize the lookup scenarios described above. But instead of classes, comment nodes are added either inside or adjacent to the target elements. These comment nodes can be quite efficiently found using a `TreeWalker` with a `NodeFilter.SHOW_COMMENT` filter. (This same approach is used for a more minor optimization: evaluating XPath expressions against potentially empty repeat sets in the model.)

- For the duration of form init and entry, collections lazily build up caches into mappings:

  - Model reference -> elements with that reference, of the collection's role/type
  - Element -> index position

- In forms with repeats, adding or removing a repeat instance invalidates these caches, partially by reference hierarchy where possible. In forms without repeats, the caches are marked static on init and never invalidated.

There's room to optimize the caching logic further, but the improvement was already significant enough that I erred in favor of a simpler, aggressive (safer) cache invalidation scheme.

It's also possible that `TreeWalker` is not the ideal API for this set of optimiztions. I've explored other approaches, but they all come with tradeoffs and some of them degrade disproportionately for certain forms. But I'm happy to discuss other approaches if the `TreeWalker` solution feels questionable.

### The rest

The remaining functionality is pretty well described by individual commit notes, but again they generally follow a common theme of reducing redundant (or unnecessary) DOM interactions e.g. by:

- adding caching where known safe
- deferring operations which aren't needed (or needed yet)
- front loading some work to make future repetitive work less necessary
- short circuiting operations redundantly triggered at multiple depths in a DOM subtree

By relying heavily on profiling real forms of various shapes, the combined set of changes address many of the heaviest operations used by those forms. With few exceptions, the heaaviest part of form init will now be XPath evaluation (which too can be optimized, but which is also a more intrinsic expense for the domain).

One notable exception is the bench6 form's most expensive operation: dispatch of several jQuery events which are not in use by Enketo at all, almost entirely by the `bootstrap-datepicker` library, which account for ~10% of its optimized init time.

## Impact 🎉

These times were taken with [enketo-core-performance-monitor](https://github.com/enketo/enketo-core-performance-monitor), against the forms we currently monitor plus the SOAR form which has also been an optimization target. Minor modifications were made to the benchmark logic to:

- Improve accuracy by ensuring timing blocks until initial loading completes
- Improve accuracy by performing measurements directly in the headless browser to eliminate any overhead from Puppeteer
- Enable the `excludeNonRelevant` setting, because it's the generally expected/preferred behavior, and because it's also historically caused a performance penalty

I think we may want to bring these changes into the performance monitor repo.

| Form                 | Render Before | Render After    | Validate Before | Validate After  |
|----------------------|---------------|-----------------|-----------------|-----------------|
| bench6               | 4438 ms       | 1067 ms (24.0%) | 3195 ms         | 422 ms (13.20%) |
| SOAR_facilitysurvey… | 2547 ms       | 761 ms (29.8%)  | 615 ms          | 181 ms (29.43%) |
| bench1               | 1022 ms       | 648 ms (63.4%)  | 176 ms          | 47 ms (26.70%)  |
| burundi              | 782 ms        | 700 ms (89.5%)  | 355 ms          | 262 ms (73.80%) |
| calc_n_footprint_29  | 752 ms        | 483 ms (64.2%)  | 34 ms           | 16 ms (47.05%)  |
| uganda               | 714 ms        | 576 ms (80.6%)  | 400 ms          | 319 ms (79.75%) |
| bench12              | 711 ms        | 410 ms (57.6%)  | 510 ms          | 195 ms (38.23%) |
| bench9               | 699 ms        | 369 ms (52.7%)  | 24 ms           | 10 ms (41.66%)  |
| shop                 | 534 ms        | 303 ms (56.7%)  | 85 ms           | 39 ms (45.88%)  |
| bench11              | 488 ms        | 307 ms (62.9%)  | 378 ms          | 128 ms (33.86%) |
| lagtest50            | 372 ms        | 323 ms (86.8%)  | 57 ms           | 52 ms (91.22%)  |
| ukraine              | 323 ms        | 275 ms (85.1%)  | 90 ms           | 48 ms (53.33%)  |
| bench10              | 291 ms        | 253 ms (86.9%)  | 65 ms           | 47 ms (72.30%)  |
| sdiprofile           | 290 ms        | 205 ms (70.6%)  | 80 ms           | 47 ms (58.75%)  |
| haiti                | 269 ms        | 263 ms (97.7%)  | 91 ms           | 68 ms (74.72%)  |
| iraq                 | 247 ms        | 217 ms (87.8%)  | 79 ms           | 45 ms (56.96%)  |
| turkey               | 230 ms        | 158 ms (68.6%)  | 49 ms           | 29 ms (59.18%)  |
| drc                  | 224 ms        | 226 ms (100.8%) | 65 ms           | 62 ms (95.38%)  |
| bench5               | 204 ms        | 183 ms (89.7%)  | 68 ms           | 34 ms (50%)     |
| widgetsdev           | 179 ms        | 159 ms (88.8%)  | 5 ms            | 6 ms (120%)     |
| car                  | 163 ms        | 138 ms (84.6%)  | 26 ms           | 25 ms (96.15%)  |
| widgets              | 159 ms        | 133 ms (83.6%)  | 2 ms            | 4 ms (200%)     |
| bench4               | 152 ms        | 122 ms (80.2%)  | 72 ms           | 33 ms (45.83%)  |
| bench2               | 124 ms        | 114 ms (91.9%)  | 31 ms           | 14 ms (45.16%)  |
| bench3               | 116 ms        | 106 ms (91.3%)  | 10 ms           | 10 ms (100%)    |
| bench8               | 107 ms        | 94 ms (87.8%)   | 3 ms            | 4 ms (133.33%)  |
| bench7               | 107 ms        | 80 ms (74.7%)   | 19 ms           | 15 ms (78.94%)  |
