### PR TITLE
Fix: Respect existing val of type='time'

### DIFF
--- a/src/js/input.js
+++ b/src/js/input.js
@@ -326,12 +326,16 @@ export default {
                     // Use today's date to incorporate daylight savings changes,
                     // Strip the thousands of a second, because most browsers fail to parse such a time.
                     // Add a space before the timezone offset to satisfy some browsers.
-                    const ds = `${new Date().toLocaleDateString('en', {
+                    const todayDate = new Date().toLocaleDateString('en', {
                         month: 'short',
                         day: 'numeric',
                         year: 'numeric',
-                    })}`;
-                    const d = new Date(ds);
+                    });
+                    const valueTime = value.replace(
+                        /(\d\d:\d\d:\d\d)(\.\d{1,3})(\s?((\+|-)\d\d))(:)?(\d\d)?/,
+                        '$1 GMT$3$7'
+                    );
+                    const d = new Date(`${todayDate} ${valueTime}`);
                     if (d.toString() !== 'Invalid Date') {
                         value = `${d.getHours().toString().padStart(2, '0')}:${d
                             .getMinutes()


### PR DESCRIPTION
Fixes https://github.com/enketo/enketo-core/issues/979.

Regression and fix described there, https://github.com/enketo/enketo-core/issues/979#issuecomment-1574444845:

> I found the change that caused this regression.
> https://github.com/enketo/enketo-core/commit/3accdd849662921b73966d7f29e3ffb109ddab56#diff-caad802f244c59940e6441fa0684b96b8c791470596c23de562f204c2dd1da40
> 
> It look like when dropping support for IE, this:
> 
> ```js
> // For IE11, we also need to strip the Left-to-Right marks \u200E...
> const ds = `${new Date()
>     .toLocaleDateString('en', {
>         month: 'short',
>         day: 'numeric',
>         year: 'numeric',
>     })
>     .replace(/\u200E/g, '')} ${value.replace(
>     /(\d\d:\d\d:\d\d)(\.\d{1,3})(\s?((\+|-)\d\d))(:)?(\d\d)?/,
>     '$1 GMT$3$7'
> )}`;
> const d = new Date(ds);
> ```
> was simplified to this:
> ```js
> const ds = `${new Date().toLocaleDateString('en', {
>     month: 'short',
>     day: 'numeric',
>     year: 'numeric',
> })}`;
> const d = new Date(ds);
> ```
> 
> The intention with that commit was to remove `.replace(/\u200E/g, '')`, as IE support is no longer needed.
> I think that `${value.replace(...)` was removed by accident.
> 
> <hr>
> 
> Here is my proposed fix, which makes it a bit clearer what is actually supposed to happen here.
> ```js
> const todayDate = new Date().toLocaleDateString('en', {
>     month: 'short',
>     day: 'numeric',
>     year: 'numeric',
> });
> const valueTime = value.replace(
>     /(\d\d:\d\d:\d\d)(\.\d{1,3})(\s?((\+|-)\d\d))(:)?(\d\d)?/,
>     '$1 GMT$3$7'
> );
> const d = new Date(`${todayDate} ${valueTime}`);
> ```
> 
> I will put together a PR for this.