### PR TITLE
Fix: include widgets with 'form' selector

### DIFF
--- a/src/js/widgets-controller.js
+++ b/src/js/widgets-controller.js
@@ -29,7 +29,8 @@ const initForm = (formElement) => {
     widgets = _widgets.filter(
         (widget) =>
             widget.selector &&
-            formElement.querySelector(widget.selector) != null
+            (widget.selector === 'form' ||
+                formElement.querySelector(widget.selector) != null)
     );
 };
 


### PR DESCRIPTION
Fixes #989. This affects the built-in textarea and radiopicker widgets, as well as any custom widgets with `selector: 'form'`.

Like #990, this would ideally have been caught by tests. But I feel more confident that this is a sufficient change to keep this particular optimization intact, with tests to come when we reintroduce the optimizations rolled back in #990.

We should also seriously consider not using/supporting a `'form'` selector for widgets in general. To the extent it makes sense to have widget logic applied form-wide, we should have a design which addresses that separately from `selector`.